### PR TITLE
Missing required fields from spec

### DIFF
--- a/versions/2.x/models/Event.json
+++ b/versions/2.x/models/Event.json
@@ -10,7 +10,8 @@
     "name",
     "location",
     "activity",
-    "organizer"
+    "organizer",
+    "offers"
   ],
   "requiredOptions": [
     {
@@ -37,7 +38,6 @@
     "level",
     "maximumAttendeeCapacity",
     "remainingAttendeeCapacity",
-    "offers",
     "startDate",
     "endDate"
   ],
@@ -403,11 +403,11 @@
       "description": [
         "The person or organization ultimately responsible for an event. An organizer might be an  schema:Organization or a schema:Person."
       ],
-      "example": [ {
+      "example": {
         "name": "Central Speedball Association",
         "type": "Organization",
         "url": "http://www.speedball-world.com"
-      } ]
+      }
     },
     "potentialAction": {
       "fieldName": "potentialAction",

--- a/versions/2.x/models/FacilityUse.json
+++ b/versions/2.x/models/FacilityUse.json
@@ -267,7 +267,12 @@
       "module": "#Organization",
       "description": [
         "The organisation responsible for providing the facility"
-      ]
+      ],
+      "example": {
+        "name": "Central Speedball Association",
+        "type": "Organization",
+        "url": "http://www.speedball-world.com"
+      }
     },
     "offers": {
       "fieldName": "offers",

--- a/versions/2.x/models/Place.json
+++ b/versions/2.x/models/Place.json
@@ -8,13 +8,22 @@
     "type",
     "name"
   ],
+  "requiredOptions": [
+    {
+      "description": [
+        "While these properties are marked as recommended, a data publisher must provide a schema:address and/or specify a oa:geo for an event. Ideally both would be included."
+      ],
+      "options": [
+        "address",
+        "geo"
+      ]
+    }
+  ],
   "recommendedFields": [
     "id",
     "url",
     "description",
     "image",
-    "address",
-    "geo",
     "telephone",
     "openingHoursSpecification",
     "amenityFeature"

--- a/versions/2.x/models/SessionSeries.json
+++ b/versions/2.x/models/SessionSeries.json
@@ -13,8 +13,7 @@
     "ageRange",
     "genderRestriction",
     "leader",
-    "level",
-    "offers"
+    "level"
   ],
   "fields": {
     "type": {

--- a/versions/2.x/models/Slot.json
+++ b/versions/2.x/models/Slot.json
@@ -9,7 +9,8 @@
     "facilityUse",
     "startDate",
     "duration",
-    "remainingUses"
+    "remainingUses",
+    "offers"
   ],
   "recommendedFields": [
     "id",


### PR DESCRIPTION
Emergency adjustment to required fields in advance of discussion regarding these being forgotten

It was previously possible to create an event without a price or location! (`offers`, `geo` or `address`).