### PR TITLE
Added repeatFrequency to requiredOptions for schedule

### DIFF
--- a/versions/2.x/models/Schedule.json
+++ b/versions/2.x/models/Schedule.json
@@ -12,12 +12,13 @@
   "requiredOptions": [
     {
       "description": [
-        "While these properties are marked as optional, a data publisher must provide either a schema:byDay, schema:byMonth or byMonthDay for a schedule."
+        "While these properties are marked as optional, a data publisher must provide either a `byDay`, `byMonth`, `byMonthDay` or `repeatFrequency` for a schedule."
       ],
       "options": [
         "byDay",
         "byMonth",
-        "byMonthDay"
+        "byMonthDay",
+        "repeatFrequency"
       ]
     }
   ],


### PR DESCRIPTION
It is valid to have a schedule with only repeatFrequency (e.g. "every 2 days"), without schema:byDay, schema:byMonth or byMonthDay.