### PR TITLE
SW1.5: Add test to check against schema.org namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "requires": {
+        "@types/node": "10.14.21"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "requires": {
+        "@types/node": "10.14.21"
+      }
+    },
+    "@types/node": {
+      "version": "10.14.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.21.tgz",
+      "integrity": "sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ=="
+    },
+    "@types/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
+    },
     "acorn": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
@@ -16,7 +42,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.3"
+        "acorn": "5.7.1"
       }
     },
     "ajv": {
@@ -25,10 +51,10 @@
       "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.1"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-keywords": {
@@ -61,7 +87,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-union": {
@@ -70,7 +96,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -85,15 +111,25 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -102,11 +138,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -115,7 +151,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -132,9 +168,14 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -148,7 +189,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -157,15 +198,20 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -174,7 +220,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.2"
           }
         },
         "supports-color": {
@@ -183,7 +229,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -206,7 +252,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -230,11 +276,30 @@
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -242,17 +307,22 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.4",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "debug": {
@@ -276,7 +346,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "del": {
@@ -285,14 +355,19 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -300,7 +375,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "error-ex": {
@@ -309,7 +384,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -318,11 +393,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -331,9 +406,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -348,45 +423,45 @@
       "integrity": "sha512-N/tCqlMKkyNvAvLu+zI9AqDasnSLt00K+Hu8kdsERliC9jYEc8ck12XtjvOXrBKu8fK6RrBcN9bat6Xk++9jAg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.2",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
-        "string.prototype.matchall": "^2.0.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "ajv": "6.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "4.0.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.7.0",
+        "ignore": "4.0.6",
+        "imurmurhash": "0.1.4",
+        "inquirer": "5.2.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "2.0.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "string.prototype.matchall": "2.0.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.3",
+        "text-table": "0.2.0"
       }
     },
     "eslint-config-airbnb": {
@@ -395,9 +470,9 @@
       "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^13.1.0",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "eslint-config-airbnb-base": "13.1.0",
+        "object.assign": "4.1.0",
+        "object.entries": "1.0.4"
       }
     },
     "eslint-config-airbnb-base": {
@@ -406,9 +481,9 @@
       "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "^0.1.1",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4"
+        "eslint-restricted-globals": "0.1.1",
+        "object.assign": "4.1.0",
+        "object.entries": "1.0.4"
       }
     },
     "eslint-import-resolver-node": {
@@ -417,8 +492,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -438,8 +513,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -459,16 +534,16 @@
       "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "dev": true,
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.3",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -486,8 +561,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         }
       }
@@ -504,8 +579,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -526,8 +601,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "5.7.1",
+        "acorn-jsx": "4.1.1"
       }
     },
     "esprima": {
@@ -542,7 +617,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -551,7 +626,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -572,9 +647,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.23",
+        "tmp": "0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -601,7 +676,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -610,8 +685,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "find-up": {
@@ -620,8 +695,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "flat-cache": {
@@ -630,10 +705,20 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.8",
+        "mime-types": "2.1.24"
       }
     },
     "fs.realpath": {
@@ -654,18 +739,23 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -680,12 +770,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "graceful-fs": {
@@ -700,7 +790,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -709,7 +799,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -730,13 +820,32 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+      "requires": {
+        "caseless": "0.12.0",
+        "concat-stream": "1.6.2",
+        "http-response-object": "3.0.2",
+        "parse-cache-control": "1.0.1"
+      }
+    },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "10.14.21"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -757,15 +866,14 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "5.2.0",
@@ -773,19 +881,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "5.5.11",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       }
     },
     "is-arrayish": {
@@ -800,7 +908,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -833,7 +941,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -842,7 +950,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-promise": {
@@ -857,7 +965,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-resolvable": {
@@ -875,8 +983,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -890,8 +997,8 @@
       "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.6",
-        "jasmine-core": "~3.2.0"
+        "glob": "7.1.2",
+        "jasmine-core": "3.2.1"
       }
     },
     "jasmine-core": {
@@ -912,8 +1019,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "json-schema-traverse": {
@@ -934,8 +1041,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -944,10 +1051,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -956,8 +1063,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -974,6 +1081,19 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -986,7 +1106,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1034,10 +1154,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "object-assign": {
@@ -1058,10 +1178,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       }
     },
     "object.entries": {
@@ -1070,10 +1190,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "once": {
@@ -1082,7 +1202,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -1091,7 +1211,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -1100,12 +1220,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1120,7 +1240,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -1129,7 +1249,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -1138,13 +1258,18 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "path-exists": {
@@ -1153,7 +1278,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -1186,7 +1311,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pify": {
@@ -1207,7 +1332,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -1216,7 +1341,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pluralize": {
@@ -1231,11 +1356,24 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
+    },
+    "promise": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+      "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+      "requires": {
+        "asap": "2.0.6"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -1243,15 +1381,20 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -1260,8 +1403,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -1270,9 +1413,23 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "regexp.prototype.flags": {
@@ -1281,7 +1438,7 @@
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "1.1.3"
       }
     },
     "regexpp": {
@@ -1296,8 +1453,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -1306,7 +1463,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-from": {
@@ -1321,8 +1478,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "rimraf": {
@@ -1331,7 +1488,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "run-async": {
@@ -1340,7 +1497,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rxjs": {
@@ -1351,6 +1508,11 @@
       "requires": {
         "symbol-observable": "1.0.1"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1370,7 +1532,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -1391,7 +1553,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "spdx-correct": {
@@ -1400,8 +1562,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -1416,8 +1578,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -1438,8 +1600,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -1448,11 +1610,19 @@
       "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.10.0",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "regexp.prototype.flags": "^1.2.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "regexp.prototype.flags": "1.2.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -1461,7 +1631,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1496,18 +1666,36 @@
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
     },
+    "sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+      "requires": {
+        "http-response-object": "3.0.2",
+        "sync-rpc": "1.3.6",
+        "then-request": "6.0.2"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "requires": {
+        "get-port": "3.2.0"
+      }
+    },
     "table": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.5.2",
+        "ajv-keywords": "3.2.0",
+        "chalk": "2.4.1",
+        "lodash": "4.17.10",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "text-table": {
@@ -1515,6 +1703,31 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+      "requires": {
+        "@types/concat-stream": "1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "8.10.54",
+        "@types/qs": "6.5.3",
+        "caseless": "0.12.0",
+        "concat-stream": "1.6.2",
+        "form-data": "2.5.1",
+        "http-basic": "8.1.3",
+        "http-response-object": "3.0.2",
+        "promise": "8.0.3",
+        "qs": "6.9.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.54",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+          "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg=="
+        }
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -1528,7 +1741,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "type-check": {
@@ -1537,8 +1750,13 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -1546,8 +1764,13 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -1555,8 +1778,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "which": {
@@ -1565,7 +1788,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "wordwrap": {
@@ -1586,7 +1809,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "test-debug": "node --inspect-brk -i ./node_modules/jasmine/bin/jasmine.js",
     "postpublish": "git push",
     "publish-patch": "npm test && git pull && git push && npm version patch && npm publish"
+  },
+  "dependencies": {
+    "sync-request": "^6.1.0"
   }
 }

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -1,11 +1,26 @@
 const fs = require('fs');
 const path = require('path');
+const request = require('sync-request');
 
 const getMetaData = require('./getMetaData');
 const derivePrefix = require('./helpers/derivePrefix');
 
 const loadModelFromFile = require('./loadModelFromFile');
 const versions = require('./versions');
+
+const schemaOrgDataModels = (() => {
+  const pendingResponse = request('GET', 'https://schema.org/version/latest/ext-pending.jsonld', {
+    accept: 'application/ld+json',
+  });
+  const pendingIds = JSON.parse(pendingResponse.body)['@graph'].map(model => model['@id']);
+
+  const mainResponse = request('GET', 'https://schema.org/version/latest/schema.jsonld', {
+    accept: 'application/ld+json',
+  });
+  const mainIds = JSON.parse(mainResponse.body)['@graph'].map(model => model['@id']);
+
+  return [...pendingIds, ...mainIds];
+})();
 
 const forEachVersion = (cb) => {
   const uniqueVersions = [...new Set(Object.values(versions))];

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -84,6 +84,16 @@ describe('models', () => {
           }
         });
 
+        it('should check that any schema.org class that a model derives from actually exists', () => {
+          if (
+            typeof jsonData.derivedFrom === 'string'
+              && jsonData.derivedFrom.match(/^https:\/\/schema.org/)
+          ) {
+            const derivedFromClassId = jsonData.derivedFrom.replace(/^https/, 'http');
+            expect(schemaOrgDataModels.includes(derivedFromClassId)).toBe(true);
+          }
+        });
+
         it('should have an idFormat and sampleId if hasId is true', () => {
           if (typeof jsonData.hasId !== 'undefined') {
             expect(typeof jsonData.hasId).toBe('boolean');

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -84,6 +84,22 @@ describe('models', () => {
           }
         });
 
+        it('should check fields actually exist as properties from schema.org when model is derivedFrom from a schema.org class', () => {
+          if (typeof jsonData.derivedFrom === 'string' && jsonData.derivedFrom.match(/^https:\/\/schema.org/)) {
+            for (const field in jsonData.fields) {
+              if (
+                Object.prototype.hasOwnProperty.call(jsonData.fields, field)
+                  && typeof jsonData.fields[field].sameAs === 'undefined'
+                  && field !== 'type'
+              ) {
+                const impliedPropertyId = `http://schema.org/${field}`;
+                const actual = schemaOrgDataModels.includes(impliedPropertyId);
+                expect(actual).toBe(true);
+              }
+            }
+          }
+        });
+
         it('should check that any schema.org class that a model derives from actually exists', () => {
           if (
             typeof jsonData.derivedFrom === 'string'

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -71,6 +71,19 @@ describe('models', () => {
           expect(`${jsonData.type.toLowerCase()}.json`).toEqual(file.toLowerCase());
         });
 
+        it('should check sameAs on fields actually exist when they are properties from schema.org', () => {
+          for (const field in jsonData.fields) {
+            if (
+              Object.prototype.hasOwnProperty.call(jsonData.fields, field)
+                && typeof jsonData.fields[field].sameAs === 'string'
+                && jsonData.fields[field].sameAs.match(/^https:\/\/schema.org/)
+            ) {
+              const propertyId = jsonData.fields[field].sameAs.replace(/^https/, 'http');
+              expect(schemaOrgDataModels.includes(propertyId)).toBe(true);
+            }
+          }
+        });
+
         it('should have an idFormat and sampleId if hasId is true', () => {
           if (typeof jsonData.hasId !== 'undefined') {
             expect(typeof jsonData.hasId).toBe('boolean');

--- a/versions/2.x/models/CancellationNotPermittedError.json
+++ b/versions/2.x/models/CancellationNotPermittedError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "CancellationNotPermittedError", 
+            "fieldName": "type",
+            "requiredContent": "CancellationNotPermittedError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "CancellationNotPermittedError"
 }

--- a/versions/2.x/models/DropdownFormFieldSpecification.json
+++ b/versions/2.x/models/DropdownFormFieldSpecification.json
@@ -41,7 +41,8 @@
          "requiredType":"ArrayOf#https://schema.org/Text",
          "description":[
             "Specifies an array of display values for the dropdown."
-         ]
+         ],
+         "sameAs":"https://openactive.io/valueOption"
       }
    }
 }

--- a/versions/2.x/models/DynamicPayment.json
+++ b/versions/2.x/models/DynamicPayment.json
@@ -24,10 +24,21 @@
       "identifier",
       "paymentMethod",
       "accountId",
-      "paymentProviderId"
+      "paymentProviderId",
+      "url",
+      "sameAs",
+      "identifier",
+      "image",
+      "potentialAction",
+      "description"
    ],
    "notInSpec":[
-
+     "url",
+     "sameAs",
+     "identifier",
+     "image",
+     "potentialAction",
+     "description"
    ],
    "fields":{
      "type": {

--- a/versions/2.x/models/Event.json
+++ b/versions/2.x/models/Event.json
@@ -3,7 +3,7 @@
   "derivedFrom": "https://schema.org/Event",
   "hasId": true,
   "idFormat": "https://schema.org/URL",
-  "sampleId": "https://example.com/event/",
+  "sampleId": "https://example.com/event/12345",
   "requiredFields": [
     "type",
     "url",
@@ -44,7 +44,6 @@
   ],
   "inSpec": [
     "id",
-    "@context",
     "type",
     "identifier",
     "url",
@@ -85,17 +84,6 @@
       "fieldName": "type",
       "requiredType": "https://schema.org/Text",
       "requiredContent": "Event"
-    },
-    "@context": {
-      "fieldName": "@context",
-      "requiredType": "https://schema.org/URL",
-      "alternativeTypes": [
-        "ArrayOf#https://schema.org/URL"
-      ],
-      "description": [
-        "This must be included in the top-most entity in the JSON model."
-      ],
-      "example": "https://openactive.io/"
     },
     "accessibilityInformation": {
       "fieldName": "accessibilityInformation",

--- a/versions/2.x/models/FacilityUse.json
+++ b/versions/2.x/models/FacilityUse.json
@@ -23,7 +23,6 @@
   "inSpec": [
     "type",
     "id",
-    "@context",
     "url",
     "identifier",
     "name",
@@ -47,17 +46,6 @@
       "fieldName": "type",
       "requiredType": "https://schema.org/Text",
       "requiredContent": "FacilityUse"
-    },
-    "@context": {
-      "fieldName": "@context",
-      "requiredType": "https://schema.org/URL",
-      "alternativeTypes": [
-        "ArrayOf#https://schema.org/URL"
-      ],
-      "description": [
-          "This must be included in the top-most entity in the JSON model."
-      ],
-      "example": "https://openactive.io/"
     },
     "accessibilityInformation": {
       "fieldName": "accessibilityInformation",

--- a/versions/2.x/models/GoneError.json
+++ b/versions/2.x/models/GoneError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "GoneError", 
+            "fieldName": "type",
+            "requiredContent": "GoneError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "GoneError"
 }

--- a/versions/2.x/models/IncompleteAttendeeDetailsError.json
+++ b/versions/2.x/models/IncompleteAttendeeDetailsError.json
@@ -1,31 +1,46 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "IncompleteAttendeeDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "IncompleteAttendeeDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "requiredFields": [
+        "type"
+    ],
+    "subClassOf": "#OpenBookingError",
     "type": "IncompleteAttendeeDetailsError"
 }

--- a/versions/2.x/models/IncompleteBrokerDetailsError.json
+++ b/versions/2.x/models/IncompleteBrokerDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "IncompleteBrokerDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "IncompleteBrokerDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "IncompleteBrokerDetailsError"
 }

--- a/versions/2.x/models/IncompleteCustomerDetailsError.json
+++ b/versions/2.x/models/IncompleteCustomerDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "IncompleteCustomerDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "IncompleteCustomerDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "IncompleteCustomerDetailsError"
 }

--- a/versions/2.x/models/IncompleteIntakeFormError.json
+++ b/versions/2.x/models/IncompleteIntakeFormError.json
@@ -15,7 +15,12 @@
         "method",
         "status",
         "invalidParams",
-        "requestId"
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
     ],
     "recommendedFields": [
         "name",
@@ -26,6 +31,13 @@
     "requiredFields": [
         "type"
     ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
     "subClassOf": "#OpenBookingError",
     "type": "IncompleteIntakeFormError"
 }

--- a/versions/2.x/models/IncompleteOrderItemError.json
+++ b/versions/2.x/models/IncompleteOrderItemError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "IncompleteOrderItemError", 
+            "fieldName": "type",
+            "requiredContent": "IncompleteOrderItemError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "IncompleteOrderItemError"
 }

--- a/versions/2.x/models/IncompletePaymentDetailsError.json
+++ b/versions/2.x/models/IncompletePaymentDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "IncompletePaymentDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "IncompletePaymentDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "IncompletePaymentDetailsError"
 }

--- a/versions/2.x/models/IndividualFacilityUse.json
+++ b/versions/2.x/models/IndividualFacilityUse.json
@@ -24,7 +24,6 @@
   "inSpec": [
     "type",
     "id",
-    "@context",
     "url",
     "identifier",
     "individualFacilityUse",

--- a/versions/2.x/models/InvalidAPITokenError.json
+++ b/versions/2.x/models/InvalidAPITokenError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "InvalidAPITokenError", 
+            "fieldName": "type",
+            "requiredContent": "InvalidAPITokenError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "InvalidAPITokenError"
 }

--- a/versions/2.x/models/InvalidAuthorizationDetailsError.json
+++ b/versions/2.x/models/InvalidAuthorizationDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "InvalidAuthorizationDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "InvalidAuthorizationDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "InvalidAuthorizationDetailsError"
 }

--- a/versions/2.x/models/InvalidIntakeFormError.json
+++ b/versions/2.x/models/InvalidIntakeFormError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "InvalidIntakeFormError", 
+            "fieldName": "type",
+            "requiredContent": "InvalidIntakeFormError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "InvalidIntakeFormError"
 }

--- a/versions/2.x/models/InvalidPaymentDetailsError.json
+++ b/versions/2.x/models/InvalidPaymentDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "InvalidPaymentDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "InvalidPaymentDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "InvalidPaymentDetailsError"
 }

--- a/versions/2.x/models/Lease.json
+++ b/versions/2.x/models/Lease.json
@@ -1,6 +1,6 @@
 {
    "type":"Lease",
-   "derivedFrom": "https://schema.org/Thing",
+   "derivedFrom": "#Thing",
    "status":{
       "response":{
          "hasId":false,

--- a/versions/2.x/models/MethodNotAllowed.json
+++ b/versions/2.x/models/MethodNotAllowed.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "MethodNotAllowed", 
+            "fieldName": "type",
+            "requiredContent": "MethodNotAllowed",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "MethodNotAllowed"
 }

--- a/versions/2.x/models/NoAPITokenError.json
+++ b/versions/2.x/models/NoAPITokenError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "NoAPITokenError", 
+            "fieldName": "type",
+            "requiredContent": "NoAPITokenError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "NoAPITokenError"
 }

--- a/versions/2.x/models/NotFoundError.json
+++ b/versions/2.x/models/NotFoundError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "NotFoundError", 
+            "fieldName": "type",
+            "requiredContent": "NotFoundError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "NotFoundError"
 }

--- a/versions/2.x/models/Offer.json
+++ b/versions/2.x/models/Offer.json
@@ -148,7 +148,8 @@
          "description": [
             "Indicates whether to accept this offer, a participant must book in advance, whether they must pay on attending, or have option to do either. Values must be one of  https://openactive.io/Required,  https://openactive.io/Optional or  https://openactive.io/Unavailable."
          ],
-         "example": "https://openactive.io/Required"
+         "example": "https://openactive.io/Required",
+         "sameAs": "https://openactive.io/advanceBooking"
       },
       "description": {
          "fieldName": "description",
@@ -165,7 +166,8 @@
          "description": [
             "Indicates whether to accept this offer, a participant must pay in advance, pay when attending, or have the option to do either. Values must be one of  https://openactive.io/Required,  https://openactive.io/Optional or  https://openactive.io/Unavailable."
          ],
-         "example": "https://openactive.io/Required"
+         "example": "https://openactive.io/Required",
+         "sameAs":"https://openactive.io/prepayment"
       },
       "availableChannel": {
          "fieldName": "availableChannel",
@@ -195,7 +197,8 @@
          "requiredType": "ArrayOf#https://openactive.io/OpenBookingFlowRequirement",
          "description": [
             "Can include  https://openactive.io/OpenBookingIntakeForm,  https://openactive.io/OpenBookingAttendeeDetails,  https://openactive.io/OpenBookingApproval,  https://openactive.io/OpenBookingNegotiation,  https://openactive.io/OpenBookingMessageExchange"
-         ]
+         ],
+         "sameAs":"https://openactive.io/openBookingFlowRequirement"
       },
       "url": {
          "fieldName": "url",

--- a/versions/2.x/models/OpenBookingError.json
+++ b/versions/2.x/models/OpenBookingError.json
@@ -1,84 +1,84 @@
 {
-    "derivedFrom": "https://schema.org/Thing", 
+    "subClassOf": "#Thing", 
     "fields": {
         "description": {
             "description": [
                 "A slightly longer, human-readable summary of the problem type. It largely should not change from occurrence to occurrence of the problem, except for purposes of localization or to provide specific information about why the error occurred in that particular case."
-            ], 
-            "example": "No customer details supplied. These must be supplied for calls to C2, P, and B.", 
-            "fieldName": "description", 
-            "requiredType": "https://schema.org/Text", 
+            ],
+            "example": "No customer details supplied. These must be supplied for calls to C2, P, and B.",
+            "fieldName": "description",
+            "requiredType": "https://schema.org/Text",
             "sameAs": "https://schema.org/description"
-        }, 
+        },
         "instance": {
             "description": [
                 "The requested URL."
-            ], 
-            "fieldName": "instance", 
+            ],
+            "fieldName": "instance",
             "requiredType": "https://schema.org/URL"
-        }, 
+        },
         "invalidParams": {
             "description": [
                 "An array of invalid parameters, if appropriate."
-            ], 
-            "fieldName": "invalidParams", 
+            ],
+            "fieldName": "invalidParams",
             "requiredType": "ArrayOf#https://schema.org/Text"
-        }, 
+        },
         "method": {
             "description": [
                 "The method of the request (e.g. GET)."
-            ], 
-            "fieldName": "method", 
+            ],
+            "fieldName": "method",
             "requiredType": "https://schema.org/Text"
-        }, 
+        },
         "name": {
             "description": [
                 "A short, human-readable summary of the problem type. It should not change from occurrence to occurrence of the problem, except for purposes of localization."
-            ], 
-            "example": "No customer details supplied", 
-            "fieldName": "name", 
-            "requiredType": "https://schema.org/Text", 
+            ],
+            "example": "No customer details supplied",
+            "fieldName": "name",
+            "requiredType": "https://schema.org/Text",
             "sameAs": "https://schema.org/name"
-        }, 
+        },
         "requestId": {
             "description": [
                 "Used by technical support for diagnostics purposes."
-            ], 
-            "fieldName": "requestId", 
+            ],
+            "fieldName": "requestId",
             "requiredType": "https://schema.org/Text"
-        }, 
+        },
         "status": {
             "description": [
                 "An integer representing the HTTP status code."
-            ], 
-            "fieldName": "status", 
+            ],
+            "fieldName": "status",
             "requiredType": "https://schema.org/Integer"
-        }, 
+        },
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OpenBookingError", 
+            "fieldName": "type",
+            "requiredContent": "OpenBookingError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
         "requestId"
-    ], 
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
+    ],
     "type": "OpenBookingError"
 }

--- a/versions/2.x/models/OpenBookingError.json
+++ b/versions/2.x/models/OpenBookingError.json
@@ -1,5 +1,5 @@
 {
-    "subClassOf": "#Thing", 
+    "subClassOf": "#Thing",
     "fields": {
         "description": {
             "description": [
@@ -15,21 +15,24 @@
                 "The requested URL."
             ],
             "fieldName": "instance",
-            "requiredType": "https://schema.org/URL"
+            "requiredType": "https://schema.org/URL",
+            "sameAs": "https://openactive.io/instance"
         },
         "invalidParams": {
             "description": [
                 "An array of invalid parameters, if appropriate."
             ],
             "fieldName": "invalidParams",
-            "requiredType": "ArrayOf#https://schema.org/Text"
+            "requiredType": "ArrayOf#https://schema.org/Text",
+            "sameAs": "https://openactive.io/invalidParams"
         },
         "method": {
             "description": [
                 "The method of the request (e.g. GET)."
             ],
             "fieldName": "method",
-            "requiredType": "https://schema.org/Text"
+            "requiredType": "https://schema.org/Text",
+            "sameAs": "https://openactive.io/method"
         },
         "name": {
             "description": [
@@ -45,14 +48,16 @@
                 "Used by technical support for diagnostics purposes."
             ],
             "fieldName": "requestId",
-            "requiredType": "https://schema.org/Text"
+            "requiredType": "https://schema.org/Text",
+            "sameAs": "https://openactive.io/requestId"
         },
         "status": {
             "description": [
                 "An integer representing the HTTP status code."
             ],
             "fieldName": "status",
-            "requiredType": "https://schema.org/Integer"
+            "requiredType": "https://schema.org/Integer",
+            "sameAs": "https://openactive.io/status"
         },
         "type": {
             "fieldName": "type",
@@ -69,7 +74,12 @@
         "method",
         "status",
         "invalidParams",
-        "requestId"
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
     ],
     "recommendedFields": [
         "name",
@@ -79,6 +89,13 @@
     ],
     "requiredFields": [
         "type"
+    ],
+    "notInSpec": [
+      "url",
+      "sameAs",
+      "identifier",
+      "image",
+      "potentialAction"
     ],
     "type": "OpenBookingError"
 }

--- a/versions/2.x/models/OpportunityCapacityIsReservedByLeaseError.json
+++ b/versions/2.x/models/OpportunityCapacityIsReservedByLeaseError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OpportunityCapacityIsReservedByLeaseError", 
+            "fieldName": "type",
+            "requiredContent": "OpportunityCapacityIsReservedByLeaseError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "OpportunityCapacityIsReservedByLeaseError"
 }

--- a/versions/2.x/models/OpportunityHasInsufficientCapacityError.json
+++ b/versions/2.x/models/OpportunityHasInsufficientCapacityError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OpportunityHasInsufficientCapacityError", 
+            "fieldName": "type",
+            "requiredContent": "OpportunityHasInsufficientCapacityError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "OpportunityHasInsufficientCapacityError"
 }

--- a/versions/2.x/models/OpportunityIsFullError.json
+++ b/versions/2.x/models/OpportunityIsFullError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OpportunityIsFullError", 
+            "fieldName": "type",
+            "requiredContent": "OpportunityIsFullError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "OpportunityIsFullError"
 }

--- a/versions/2.x/models/OpportunityIsInConflictError.json
+++ b/versions/2.x/models/OpportunityIsInConflictError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OpportunityIsInConflictError", 
+            "fieldName": "type",
+            "requiredContent": "OpportunityIsInConflictError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "OpportunityIsInConflictError"
 }

--- a/versions/2.x/models/Order.json
+++ b/versions/2.x/models/Order.json
@@ -119,8 +119,8 @@
       "taxCalculationExcluded":{
         "fieldName": "taxCalculationExcluded",
         "requiredType": "https://schema.org/Boolean",
-        "description":["Set to true when business-to-business tax calculation is required by the seller or brokerRole settings, but not supported by the Broker."]
-
+        "description":["Set to true when business-to-business tax calculation is required by the seller or brokerRole settings, but not supported by the Broker."],
+        "sameAs":"https://openactive.io/taxCalculationExcluded"
       },
       "broker":{
          "fieldName":"broker",

--- a/versions/2.x/models/OrderAlreadyExistsError.json
+++ b/versions/2.x/models/OrderAlreadyExistsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OrderAlreadyExistsError", 
+            "fieldName": "type",
+            "requiredContent": "OrderAlreadyExistsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "OrderAlreadyExistsError"
 }

--- a/versions/2.x/models/OrderCreationFailedError.json
+++ b/versions/2.x/models/OrderCreationFailedError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "OrderCreationFailedError", 
+            "fieldName": "type",
+            "requiredContent": "OrderCreationFailedError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "OrderCreationFailedError"
 }

--- a/versions/2.x/models/OrderItem.json
+++ b/versions/2.x/models/OrderItem.json
@@ -128,6 +128,7 @@
       "accessToken":{
          "fieldName":"accessToken",
          "model":"#ImageObject",
+         "sameAs":"https://openactive.io/accessToken",
          "alternativeModels":[
             "#BarCode"
          ],

--- a/versions/2.x/models/OrderProposal.json
+++ b/versions/2.x/models/OrderProposal.json
@@ -96,17 +96,21 @@
       "orderProposalStatus":{
          "fieldName":"orderProposalStatus",
          "requiredType":"https://openactive.io/OrderProposalStatus",
-         "description":[ ""]
+         "description":[ ""],
+         "sameAs":"https://openactive.io/orderProposalStatus"
       },
       "orderSellerNote":{
          "fieldName":"orderSellerNote",
          "requiredType":"https://schema.org/Text",
-         "description":[ ""]
+         "description":[ ""],
+         "sameAs":"https://openactive.io/orderSellerNote"
       },
       "orderCustomerNote":{
          "fieldName":"orderCustomerNote",
          "requiredType":"https://schema.org/Text",
-         "description":[ ""]
+         "description":[""],
+         "sameAs":"https://openactive.io/orderCustomerNote"
+
       }
    }
 }

--- a/versions/2.x/models/Organization.json
+++ b/versions/2.x/models/Organization.json
@@ -53,7 +53,8 @@
       "requiredType": "https://openactive.io/TaxMode",
       "description": [
         "Either  https://openactive/TaxNet or  https://openactive/TaxGross"
-      ]
+      ],
+      "sameAs":"https://openactive.io/taxMode"
     },
     "vatID": {
       "fieldName": "vatID",

--- a/versions/2.x/models/Parking.json
+++ b/versions/2.x/models/Parking.json
@@ -1,8 +1,7 @@
 {
   "type": "Parking",
-  "derivedFrom": "https://schema.org/Thing",
+  "derivedFrom": "#Thing",
   "subClassOf": "#LocationFeatureSpecification",
-  "derivedFrom": null,
   "fields": {
     "type": {
       "fieldName": "type",

--- a/versions/2.x/models/PatchContainsExcessiveProperties.json
+++ b/versions/2.x/models/PatchContainsExcessiveProperties.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "PatchContainsExcessiveProperties", 
+            "fieldName": "type",
+            "requiredContent": "PatchContainsExcessiveProperties",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "PatchContainsExcessiveProperties"
 }

--- a/versions/2.x/models/PatchNotAllowedOnProperty.json
+++ b/versions/2.x/models/PatchNotAllowedOnProperty.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "PatchNotAllowedOnProperty", 
+            "fieldName": "type",
+            "requiredContent": "PatchNotAllowedOnProperty",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "PatchNotAllowedOnProperty"
 }

--- a/versions/2.x/models/Payment.json
+++ b/versions/2.x/models/Payment.json
@@ -1,6 +1,6 @@
 {
    "type":"Payment",
-   "derivedFrom": "https://schema.org/Thing",
+   "subClassOf": "#Thing",
    "status":{
       "response":{
          "hasId":false,
@@ -38,6 +38,7 @@
       "name":{
          "fieldName":"name",
          "requiredType":"https://schema.org/Text",
+         "sameAs":"https://schema.org/name",
          "description":["Optional free text description of the payment method for the Booking System, to help the Seller in discussions with the Customer (e.g. 'AcmeBroker Points' or 'AcmeBroker via Credit Card')."]
       },
       "identifier":{

--- a/versions/2.x/models/Payment.json
+++ b/versions/2.x/models/Payment.json
@@ -24,10 +24,21 @@
       "identifier",
       "paymentMethod",
       "accountId",
-      "paymentProviderId"
+      "paymentProviderId",
+      "url",
+      "sameAs",
+      "identifier",
+      "image",
+      "potentialAction",
+      "description"
    ],
    "notInSpec":[
-
+     "url",
+     "sameAs",
+     "identifier",
+     "image",
+     "potentialAction",
+     "description"
    ],
    "fields":{
       "type":{

--- a/versions/2.x/models/TemporarilyUnableToCreateOrderError.json
+++ b/versions/2.x/models/TemporarilyUnableToCreateOrderError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TemporarilyUnableToCreateOrderError", 
+            "fieldName": "type",
+            "requiredContent": "TemporarilyUnableToCreateOrderError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TemporarilyUnableToCreateOrderError"
 }

--- a/versions/2.x/models/TemporarilyUnableToDeleteOrderError.json
+++ b/versions/2.x/models/TemporarilyUnableToDeleteOrderError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TemporarilyUnableToDeleteOrderError", 
+            "fieldName": "type",
+            "requiredContent": "TemporarilyUnableToDeleteOrderError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TemporarilyUnableToDeleteOrderError"
 }

--- a/versions/2.x/models/TemporarilyUnableToProduceOrderQuoteError.json
+++ b/versions/2.x/models/TemporarilyUnableToProduceOrderQuoteError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TemporarilyUnableToProduceOrderQuoteError", 
+            "fieldName": "type",
+            "requiredContent": "TemporarilyUnableToProduceOrderQuoteError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TemporarilyUnableToProduceOrderQuoteError"
 }

--- a/versions/2.x/models/TemporarilyUnableToUpdateOrderError.json
+++ b/versions/2.x/models/TemporarilyUnableToUpdateOrderError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TemporarilyUnableToUpdateOrderError", 
+            "fieldName": "type",
+            "requiredContent": "TemporarilyUnableToUpdateOrderError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TemporarilyUnableToUpdateOrderError"
 }

--- a/versions/2.x/models/Thing.json
+++ b/versions/2.x/models/Thing.json
@@ -1,0 +1,89 @@
+{
+   "type":"Thing",
+   "isJsonLd":true,
+   "derivedFrom":"https://schema.org/Thing",
+   "hasId":false,
+   "requiredFields":[
+   ],
+   "recommendedFields":[
+
+   ],
+   "shallNotInclude":[
+
+   ],
+   "requiredOptions":[
+
+   ],
+   "inSpec":[
+      "type",
+      "description",
+      "identifier",
+      "image",
+      "name",
+      "sameAs",
+      "url",
+      "potentialAction"
+   ],
+   "notInSpec":[
+
+   ],
+   "fields":{
+      "type":{
+         "fieldName":"type",
+         "requiredType":"https://schema.org/Text",
+         "requiredContent":"Thing"
+      },
+      "name":{
+         "fieldName":"name",
+         "requiredType":"https://schema.org/Text",
+         "sameAs":"https://schema.org/name",
+         "description":[
+            "The name of the item."
+         ]
+      },
+      "url":{
+         "fieldName":"url",
+         "sameAs":"https://schema.org/url",
+         "requiredType":"https://schema.org/URL",
+         "description":[
+            "URL of the item."
+         ]
+      },
+      "sameAs":{
+         "fieldName":"sameAs",
+         "requiredType":"https://schema.org/url",
+         "description":[
+            "URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website."
+         ]
+      },
+      "description":{
+         "fieldName":"description",
+         "requiredType":"https://schema.org/Text",
+         "description":[
+            "A description of the item."
+         ]
+      },
+      "identifier":{
+         "fieldName":"identifier",
+         "requiredType":"https://schema.org/Text",
+         "description":[
+            "The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links."
+         ]
+      },
+      "image":{
+         "fieldName":"image",
+         "requiredType":"https://schema.org/url",
+         "description":[
+            "An image of the item. This can be a URL or a fully described ImageObject."
+         ]
+      },
+      "potentialAction":{
+         "fieldName":"potentialAction",
+         "model":"ArrayOf#Action",
+         "sameAs":"https://schema.org/potentialAction",
+         "description":[
+            "The possible actions that a user may make. e.g. Book."
+         ]
+      }
+   }
+}

--- a/versions/2.x/models/TooManyRequestsError.json
+++ b/versions/2.x/models/TooManyRequestsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TooManyRequestsError", 
+            "fieldName": "type",
+            "requiredContent": "TooManyRequestsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TooManyRequestsError"
 }

--- a/versions/2.x/models/TotalPaymentDueMismatchError.json
+++ b/versions/2.x/models/TotalPaymentDueMismatchError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "TotalPaymentDueMismatchError", 
+            "fieldName": "type",
+            "requiredContent": "TotalPaymentDueMismatchError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "TotalPaymentDueMismatchError"
 }

--- a/versions/2.x/models/UnableToProcessOrderItemError.json
+++ b/versions/2.x/models/UnableToProcessOrderItemError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnableToProcessOrderItemError", 
+            "fieldName": "type",
+            "requiredContent": "UnableToProcessOrderItemError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "UnableToProcessOrderItemError"
 }

--- a/versions/2.x/models/UnacceptableOfferError.json
+++ b/versions/2.x/models/UnacceptableOfferError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnacceptableOfferError", 
+            "fieldName": "type",
+            "requiredContent": "UnacceptableOfferError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "UnacceptableOfferError"
 }

--- a/versions/2.x/models/UnauthenticatedError.json
+++ b/versions/2.x/models/UnauthenticatedError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnauthenticatedError", 
+            "fieldName": "type",
+            "requiredContent": "UnauthenticatedError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "UnauthenticatedError"
 }

--- a/versions/2.x/models/UnavailableOpportunityError.json
+++ b/versions/2.x/models/UnavailableOpportunityError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnavailableOpportunityError", 
+            "fieldName": "type",
+            "requiredContent": "UnavailableOpportunityError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "UnavailableOpportunityError"
 }

--- a/versions/2.x/models/UnknownOfferError.json
+++ b/versions/2.x/models/UnknownOfferError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnknownOfferError", 
+            "fieldName": "type",
+            "requiredContent": "UnknownOfferError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "UnknownOfferError"
 }

--- a/versions/2.x/models/UnknownOpportunityDetailsError.json
+++ b/versions/2.x/models/UnknownOpportunityDetailsError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnknownOpportunityDetailsError", 
+            "fieldName": "type",
+            "requiredContent": "UnknownOpportunityDetailsError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "UnknownOpportunityDetailsError"
 }

--- a/versions/2.x/models/UnknownOrIncorrectEndpointError.json
+++ b/versions/2.x/models/UnknownOrIncorrectEndpointError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnknownOrIncorrectEndpointError", 
+            "fieldName": "type",
+            "requiredContent": "UnknownOrIncorrectEndpointError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ], 
+    "subClassOf": "#OpenBookingError",
     "type": "UnknownOrIncorrectEndpointError"
 }

--- a/versions/2.x/models/UnknownOrderError.json
+++ b/versions/2.x/models/UnknownOrderError.json
@@ -1,31 +1,43 @@
 {
     "fields": {
         "type": {
-            "fieldName": "type", 
-            "requiredContent": "UnknownOrderError", 
+            "fieldName": "type",
+            "requiredContent": "UnknownOrderError",
             "requiredType": "https://schema.org/Text"
         }
-    }, 
-    "hasId": false, 
+    },
+    "hasId": false,
     "inSpec": [
-        "type", 
-        "name", 
-        "description", 
-        "instance", 
-        "method", 
-        "status", 
-        "invalidParams", 
-        "requestId"
-    ], 
+        "type",
+        "name",
+        "description",
+        "instance",
+        "method",
+        "status",
+        "invalidParams",
+        "requestId",
+        "url",
+        "sameAs",
+        "identifier",
+        "image",
+        "potentialAction"
+    ],
     "recommendedFields": [
-        "name", 
-        "description", 
-        "instance", 
+        "name",
+        "description",
+        "instance",
         "method"
-    ], 
+    ],
     "requiredFields": [
         "type"
-    ], 
-    "subClassOf": "#OpenBookingError", 
+    ],
+    "notInSpec": [
+          "url",
+          "sameAs",
+          "identifier",
+          "image",
+          "potentialAction"
+        ],
+    "subClassOf": "#OpenBookingError",
     "type": "UnknownOrderError"
 }


### PR DESCRIPTION
Based on #27 
This checks the existence of various schema.org classes and properties referenced by the model files (via `sameAs` and `derivedFrom` keys on fields and models respectively) by checking the values in the JSONLD representation published by schema.org (https://schema.org/version/latest/schema.jsonld).

Note:
- The field call type is ignored (because it is different so not expected to be ever be a schema.org property - see #34 for how it could be validated)