### PR TITLE
SW1.5: add test to models to check all notInSpec entries are included in fields of parent model

### DIFF
--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -236,6 +236,7 @@ describe('models', () => {
             expect(jsonData.fields.type.requiredContent).toMatch(/^[a-zA-Z]+$/);
           }
         });
+
         describe('alternativeModels', () => {
           it('should only include entries defined in models json', () => {
             for (const field in jsonData.fields) {
@@ -253,6 +254,21 @@ describe('models', () => {
                   });
                 }
               }
+            }
+          });
+        });
+
+        describe('notInSpec', () => {
+          it('should only include fields present in the parentModel', () => {
+            if (
+              typeof jsonData.notInSpec === 'object'
+              && jsonData.notInSpec.length > 0
+            ) {
+              const parentModelName = jsonData.subClassGraph[0].replace(/^#/, '');
+              const parentModel = loadModelFromFile(parentModelName, version);
+              jsonData.notInSpec.forEach((notInSpecField) => {
+                expect(Object.hasOwnProperty.call(parentModel.fields, notInSpecField)).toBe(true);
+              });
             }
           });
         });


### PR DESCRIPTION
Fixes #25 - adds a test to ensure that anything in a the notInSpec array for a model is a field from the parent model.
