### PR TITLE
Sw1.5/issue 29 validate model and required type

### DIFF
--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -352,6 +352,16 @@ describe('models', () => {
           });
         });
 
+        it('should only use valid classes with for requiredType property of a field spec', () => {
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (
+              typeof fieldSpec.requiredType === 'string'
+            ) {
+              expect(fieldSpec.requiredType).toBeValidClassReference();
+            }
+          });
+        });
+
         describe('alternativeModels', () => {
           it('should only include entries defined in models json', () => {
             forEachField(jsonData, (field, fieldSpec) => {

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -307,6 +307,16 @@ describe('models', () => {
           }
         });
 
+        it('should only use existing models for models property of a field spec', () => {
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (
+              typeof fieldSpec.model === 'string'
+            ) {
+              expect(fieldSpec.model).toBeValidModelReference();
+            }
+          });
+        });
+
         describe('alternativeModels', () => {
           it('should only include entries defined in models json', () => {
             forEachField(jsonData, (field, fieldSpec) => {

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -49,6 +49,15 @@ const forEachVersionedFile = (cb) => {
   });
 };
 
+const forEachField = (model, cb) => {
+  for (const field in model.fields) {
+    if (Object.prototype.hasOwnProperty.call(model.fields, field)) {
+      const fieldSpec = model.fields[field];
+      cb(field, fieldSpec);
+    }
+  }
+};
+
 describe('models', () => {
   forEachVersionedFile((version, metaData, modelsDirpath, rpdeDirpath, file, data) => {
     const fieldNameToNamespaced = {};
@@ -196,90 +205,74 @@ describe('models', () => {
         });
 
         it('should have inSpec value for everything in fields', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              expect(jsonData.inSpec).toContain(field);
-            }
-          }
+          forEachField(jsonData, (field) => {
+            expect(jsonData.inSpec).toContain(field);
+          });
         });
 
         it('should have fields with names that match their keys', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              expect(jsonData.fields[field].fieldName).toBeDefined();
-              expect(jsonData.fields[field].fieldName).toBe(field);
-            }
-          }
+          forEachField(jsonData, (field, fieldSpec) => {
+            expect(fieldSpec.fieldName).toBeDefined();
+            expect(fieldSpec.fieldName).toBe(field);
+          });
         });
 
         it('should have fields with either a requiredType or model', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              expect(
-                typeof jsonData.fields[field].model === 'undefined'
-                || typeof jsonData.fields[field].requiredType === 'undefined',
-              ).toBe(true);
-            }
-          }
+          forEachField(jsonData, (field, fieldSpec) => {
+            expect(
+              typeof fieldSpec.model === 'undefined'
+              || typeof fieldSpec.requiredType === 'undefined',
+            ).toBe(true);
+          });
         });
 
         it('should have fields with a model property that points to real models', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              if (typeof jsonData.fields[field].model !== 'undefined') {
-                expect(jsonData.fields[field].model).toMatch(/^(ArrayOf)?#[A-Za-z]+$/);
-              }
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (typeof fieldSpec.model !== 'undefined') {
+              expect(fieldSpec.model).toMatch(/^(ArrayOf)?#[A-Za-z]+$/);
             }
-          }
+          });
         });
 
         it('should have fields with an additionalModels property that are arrays pointing to real models', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              if (typeof jsonData.fields[field].additionalModels !== 'undefined') {
-                expect(jsonData.fields[field].additionalModels instanceof Array).toBe(true);
-                for (const model of jsonData.fields[field].additionalModels) {
-                  expect(model).toMatch(/^(ArrayOf)?#[A-Za-z]+$/);
-                }
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (typeof fieldSpec.additionalModels !== 'undefined') {
+              expect(fieldSpec.additionalModels instanceof Array).toBe(true);
+              for (const model of fieldSpec.additionalModels) {
+                expect(model).toMatch(/^(ArrayOf)?#[A-Za-z]+$/);
               }
             }
-          }
+          });
         });
 
         it('should have fields with a type property that points to real types', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              if (typeof jsonData.fields[field].requiredType !== 'undefined') {
-                expect(jsonData.fields[field].requiredType).toMatch(/^(ArrayOf#)?(https:\/\/schema\.org\/|https:\/\/openactive\.io\/|http:\/\/purl\.org\/goodrelations\/v1#)[a-zA-Z]+$/);
-              }
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (typeof fieldSpec.requiredType !== 'undefined') {
+              expect(fieldSpec.requiredType).toMatch(/^(ArrayOf#)?(https:\/\/schema\.org\/|https:\/\/openactive\.io\/|http:\/\/purl\.org\/goodrelations\/v1#)[a-zA-Z]+$/);
             }
-          }
+          });
         });
 
         it('should have fields with an additionalTypes property that are arrays pointing to real models', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              if (typeof jsonData.fields[field].additionalTypes !== 'undefined') {
-                expect(jsonData.fields[field].additionalTypes instanceof Array).toBe(true);
-                for (const type of jsonData.fields[field].additionalTypes) {
-                  expect(type).toMatch(/^(ArrayOf#)?http:\/\/(schema\.org|openactive\.io)\/[a-zA-Z]+$/);
-                }
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (typeof fieldSpec.additionalTypes !== 'undefined') {
+              expect(fieldSpec.additionalTypes instanceof Array).toBe(true);
+              for (const type of fieldSpec.additionalTypes) {
+                expect(type).toMatch(/^(ArrayOf#)?http:\/\/(schema\.org|openactive\.io)\/[a-zA-Z]+$/);
               }
             }
-          }
+          });
         });
 
         it('should have fields with a description property that is an array of strings, unless it is a type', () => {
-          for (const field in jsonData.fields) {
-            if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-              if (typeof jsonData.fields[field].description !== 'undefined') {
-                expect(jsonData.fields[field].description instanceof Array
-                  && jsonData.fields[field].description.filter(item => typeof item !== 'string').length === 0).toBe(true, field);
-              } else if (field !== 'type') {
-                fail(`Does not have description, '${field}'.`);
-              }
+          forEachField(jsonData, (field, fieldSpec) => {
+            if (typeof fieldSpec.description !== 'undefined') {
+              expect(fieldSpec.description instanceof Array
+                && fieldSpec.description.filter(item => typeof item !== 'string').length === 0).toBe(true, field);
+            } else if (field !== 'type') {
+              fail(`Does not have description, '${field}'.`);
             }
-          }
+          });
         });
 
         it('should have "type" with only exactly the properties fieldName, requiredType, requiredContent; and with requiredType as "https://schema.org/Text".', () => {
@@ -293,22 +286,19 @@ describe('models', () => {
 
         describe('alternativeModels', () => {
           it('should only include entries defined in models json', () => {
-            for (const field in jsonData.fields) {
-              if (Object.prototype.hasOwnProperty.call(jsonData.fields, field)) {
-                const fieldSpec = jsonData.fields[field];
-                if (
-                  typeof fieldSpec.alternativeModels === 'object'
-                  && fieldSpec.alternativeModels.length > 0
-                ) {
-                  fieldSpec.alternativeModels.forEach((alternativeModel) => {
-                    const alternativeModelShortName = alternativeModel.replace(/^(ArrayOf)?#/, '');
-                    const alternativeModelFilename = `${alternativeModelShortName}.json`;
-                    const alternativeModelExpectedFilepath = path.join(modelsDirpath, alternativeModelFilename);
-                    expect(fs.existsSync(alternativeModelExpectedFilepath)).toBe(true);
-                  });
-                }
+            forEachField(jsonData, (field, fieldSpec) => {
+              if (
+                typeof fieldSpec.alternativeModels === 'object'
+                && fieldSpec.alternativeModels.length > 0
+              ) {
+                fieldSpec.alternativeModels.forEach((alternativeModel) => {
+                  const alternativeModelShortName = alternativeModel.replace(/^(ArrayOf)?#/, '');
+                  const alternativeModelFilename = `${alternativeModelShortName}.json`;
+                  const alternativeModelExpectedFilepath = path.join(modelsDirpath, alternativeModelFilename);
+                  expect(fs.existsSync(alternativeModelExpectedFilepath)).toBe(true);
+                });
               }
-            }
+            });
           });
         });
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -89,6 +89,11 @@ describe('models', () => {
       },
 
       toBeValidTypeReference() {
+        const adHocValidTypes = [
+          // these are a selection of terms in vocab that can't so easily be validated (e.g. no JSON-LD file to check against)
+          'http://purl.org/goodrelations/v1#PaymentMethod',
+        ];
+
         return {
           compare(typeRef) {
             const result = {};
@@ -105,6 +110,8 @@ describe('models', () => {
               if (!result.pass) {
                 result.message = `${typeRef} is not a valid Open Active reference`;
               }
+            } else if (adHocValidTypes.includes(typeId)) {
+              result.pass = true;
             } else {
               throw new Error(`unrecognished type ${typeId}`);
             }

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -68,7 +68,7 @@ describe('models', () => {
 
     const modelExists = (modelName) => {
       const modelFilename = `${modelName}.json`;
-      const modelExpectedFilepath = path.join(modelsDirpath, modelFilename);
+      const modelExpectedFilepath = modelName.match(/^Feed/) ? path.join(rpdeDirpath, modelFilename) : path.join(modelsDirpath, modelFilename);
       return fs.existsSync(modelExpectedFilepath);
     };
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -61,6 +61,29 @@ const forEachField = (model, cb) => {
 describe('models', () => {
   forEachVersionedFile((version, metaData, modelsDirpath, rpdeDirpath, file, data) => {
     const fieldNameToNamespaced = {};
+
+    const customMatchers = {
+      toBeValidModelReference() {
+        return {
+          compare(modelRef) {
+            const modelName = modelRef.replace(/^(ArrayOf)?#/, '');
+            const modelFilename = `${modelName}.json`;
+            const modelExpectedFilepath = path.join(modelsDirpath, modelFilename);
+            const result = {};
+            result.pass = fs.existsSync(modelExpectedFilepath);
+            if (!result.pass) {
+              result.message = `${modelRef} is not a valid model reference`
+            }
+            return result;
+          },
+        };
+      },
+    };
+
+    beforeEach(() => {
+      jasmine.addMatchers(customMatchers);
+    });
+
     describe(`file ${file}`, () => {
       let jsonData;
 
@@ -292,10 +315,7 @@ describe('models', () => {
                 && fieldSpec.alternativeModels.length > 0
               ) {
                 fieldSpec.alternativeModels.forEach((alternativeModel) => {
-                  const alternativeModelShortName = alternativeModel.replace(/^(ArrayOf)?#/, '');
-                  const alternativeModelFilename = `${alternativeModelShortName}.json`;
-                  const alternativeModelExpectedFilepath = path.join(modelsDirpath, alternativeModelFilename);
-                  expect(fs.existsSync(alternativeModelExpectedFilepath)).toBe(true);
+                  expect(alternativeModel).toBeValidModelReference();
                 });
               }
             });

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -9,12 +9,12 @@ const derivePrefix = require('./helpers/derivePrefix');
 const loadModelFromFile = require('./loadModelFromFile');
 const versions = require('./versions');
 
-const schemaOrgDataModels = (() => {
+const schemaOrgDataModel = (() => {
   const fetchIds = (url) => {
     const response = request('GET', url, {
       accept: 'application/ld+json',
     });
-    return JSON.parse(response.body)['@graph'].map(model => model['@id']);
+    return JSON.parse(response.body)['@graph'].map(entity => entity['@id']);
   };
 
   const schemaSources = [
@@ -99,7 +99,7 @@ describe('models', () => {
             const result = {};
             const typeId = typeRef.replace(/^ArrayOf#?/, '').replace(/^https:\/\/schema.org/, 'http://schema.org');
             if (typeId.match(/^http:\/\/schema\.org/)) {
-              result.pass = schemaOrgDataModels.includes(typeId);
+              result.pass = schemaOrgDataModel.includes(typeId);
               if (!result.pass) {
                 result.message = `${typeRef} is not a valid schema.org reference`;
               }
@@ -153,7 +153,7 @@ describe('models', () => {
                 && jsonData.fields[field].sameAs.match(/^https:\/\/schema.org/)
             ) {
               const propertyId = jsonData.fields[field].sameAs.replace(/^https/, 'http');
-              expect(schemaOrgDataModels.includes(propertyId)).toBe(true);
+              expect(schemaOrgDataModel.includes(propertyId)).toBe(true);
             }
           }
         });
@@ -167,7 +167,7 @@ describe('models', () => {
                   && field !== 'type'
               ) {
                 const impliedPropertyId = `http://schema.org/${field}`;
-                const actual = schemaOrgDataModels.includes(impliedPropertyId);
+                const actual = schemaOrgDataModel.includes(impliedPropertyId);
                 expect(actual).toBe(true);
               }
             }
@@ -180,7 +180,7 @@ describe('models', () => {
               && jsonData.derivedFrom.match(/^https:\/\/schema.org/)
           ) {
             const derivedFromClassId = jsonData.derivedFrom.replace(/^https/, 'http');
-            expect(schemaOrgDataModels.includes(derivedFromClassId)).toBe(true);
+            expect(schemaOrgDataModel.includes(derivedFromClassId)).toBe(true);
           }
         });
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -9,17 +9,20 @@ const loadModelFromFile = require('./loadModelFromFile');
 const versions = require('./versions');
 
 const schemaOrgDataModels = (() => {
-  const pendingResponse = request('GET', 'https://schema.org/version/latest/ext-pending.jsonld', {
-    accept: 'application/ld+json',
-  });
-  const pendingIds = JSON.parse(pendingResponse.body)['@graph'].map(model => model['@id']);
+  const fetchIds = (url) => {
+    const response = request('GET', url, {
+      accept: 'application/ld+json',
+    });
+    return JSON.parse(response.body)['@graph'].map(model => model['@id']);
+  };
 
-  const mainResponse = request('GET', 'https://schema.org/version/latest/schema.jsonld', {
-    accept: 'application/ld+json',
-  });
-  const mainIds = JSON.parse(mainResponse.body)['@graph'].map(model => model['@id']);
+  const schemaSources = [
+    'https://schema.org/version/latest/schema.jsonld',
+    'https://schema.org/version/3.9/ext-meta.jsonld',
+    'https://schema.org/version/latest/ext-pending.jsonld',
+  ];
 
-  return [...pendingIds, ...mainIds];
+  return schemaSources.reduce((store, url) => store.concat(fetchIds(url)), []);
 })();
 
 const forEachVersion = (cb) => {

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -88,25 +88,25 @@ describe('models', () => {
         };
       },
 
-      toBeValidClassReference() {
+      toBeValidTypeReference() {
         return {
-          compare(classRef) {
+          compare(typeRef) {
             const result = {};
-            const classId = classRef.replace(/^ArrayOf#?/, '').replace(/^https:\/\/schema.org/, 'http://schema.org');
-            if (classId.match(/^http:\/\/schema\.org/)) {
-              result.pass = schemaOrgDataModels.includes(classId);
+            const typeId = typeRef.replace(/^ArrayOf#?/, '').replace(/^https:\/\/schema.org/, 'http://schema.org');
+            if (typeId.match(/^http:\/\/schema\.org/)) {
+              result.pass = schemaOrgDataModels.includes(typeId);
               if (!result.pass) {
-                result.message = `${classRef} is not a valid schema.org reference`;
+                result.message = `${typeRef} is not a valid schema.org reference`;
               }
-            } else if (classId.match(/^https:\/\/openactive.io/)) {
-              const enumName = classId.replace(/^https:\/\/openactive.io\//, '');
+            } else if (typeId.match(/^https:\/\/openactive.io/)) {
+              const typeName = typeId.replace(/^https:\/\/openactive.io\//, '');
               const enums = getEnums(version);
-              result.pass = Object.prototype.hasOwnProperty.call(enums, enumName);
+              result.pass = modelExists(typeName) || Object.prototype.hasOwnProperty.call(enums, typeName);
               if (!result.pass) {
-                result.message = `${classRef} is not a valid Open Active reference`;
+                result.message = `${typeRef} is not a valid Open Active reference`;
               }
             } else {
-              throw new Error(`unrecognished class ${classId}`);
+              throw new Error(`unrecognished type ${typeId}`);
             }
 
             return result;
@@ -151,7 +151,7 @@ describe('models', () => {
           }
         });
 
-        it('should check fields actually exist as properties from schema.org when model is derivedFrom from a schema.org class', () => {
+        it('should check fields actually exist as properties from schema.org when model is derivedFrom from a schema.org type', () => {
           if (typeof jsonData.derivedFrom === 'string' && jsonData.derivedFrom.match(/^https:\/\/schema.org/)) {
             for (const field in jsonData.fields) {
               if (
@@ -357,7 +357,7 @@ describe('models', () => {
             if (
               typeof fieldSpec.requiredType === 'string'
             ) {
-              expect(fieldSpec.requiredType).toBeValidClassReference();
+              expect(fieldSpec.requiredType).toBeValidTypeReference();
             }
           });
         });


### PR DESCRIPTION
Fixes #29 plus there's some refactoring of the models-spec file (helper to iterate over all fields of a model which is used frequently; custom matches to validate the name of a type or OA model; renamed `schemaOrgDataModels` -> `schemaOrgDataModel` because there's only one schema.org data model with many entities in it).