### PR TITLE
Sw1.5: Add test to ensure everything inherits from Thing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,12 @@
         "acorn": "5.7.1"
       }
     },
+    "add-matchers": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/add-matchers/-/add-matchers-0.6.2.tgz",
+      "integrity": "sha512-hVO2wodMei9RF00qe+506MoeJ/NEOdCMEkSJ12+fC3hx/5Z4zmhNiP92nJEF6XhmXokeB0hOtuQrjHCx2vmXrQ==",
+      "dev": true
+    },
     "ajv": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
@@ -1006,6 +1012,15 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
       "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
       "dev": true
+    },
+    "jasmine-expect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jasmine-expect/-/jasmine-expect-4.0.3.tgz",
+      "integrity": "sha512-ucHOO6qpY6/vwgxoRVzyYywIRuvGEmI1uk69INjdZ84h2dUHIXHf8A5jUkM1kQHy9lHP1jqq9/S5VAkYUsFYCg==",
+      "dev": true,
+      "requires": {
+        "add-matchers": "0.6.2"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
-    "jasmine": "^3.2.0"
+    "jasmine": "^3.2.0",
+    "jasmine-expect": "^4.0.3"
   },
   "scripts": {
     "build": "node scripts/build.js",

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -3,6 +3,7 @@
   "spec_files": [
     "**/*[sS]pec.js"
   ],
+  "helpers": ["../node_modules/jasmine-expect/index.js"],
   "stopSpecOnExpectationFailure": false,
   "random": true
 }

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -181,7 +181,7 @@ describe('models', () => {
           }
         });
 
-        it('should check that any schema.org class that a model derives from actually exists', () => {
+        it('should check that any derivedFrom property refers to a class that actually exists', () => {
           if (
             typeof jsonData.derivedFrom === 'string'
           ) {

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -122,14 +122,14 @@ describe('models', () => {
             } else if (typeId.match(/^http:\/\/www\.w3\.org\/2004\/02\/skos\/core#/)) {
               result.pass = skosDataModel.includes(typeId);
               if (!result.pass) {
-                result.message = `${typeRef} is not a valid goodrelations reference`;
+                result.message = `${typeRef} is not a valid SKOS reference`;
               }
             } else if (typeId.match(/^https:\/\/openactive.io/)) {
               const typeName = typeId.replace(/^https:\/\/openactive.io\//, '');
               const enums = getEnums(version);
               result.pass = modelExists(typeName) || Object.prototype.hasOwnProperty.call(enums, typeName);
               if (!result.pass) {
-                result.message = `${typeRef} is not a valid SKOS reference`;
+                result.message = `${typeRef} is not a valid OpenActive reference`;
               }
             } else {
               throw new Error(`unrecognished type ${typeId}`);

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -164,6 +164,30 @@ describe('models', () => {
           expect(`${jsonData.type.toLowerCase()}.json`).toEqual(file.toLowerCase());
         });
 
+        it('should be fit into the model inheritence hierarchy', () => {
+          const inheritsFrom = Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf') ? jsonData.subClassOf : jsonData.derivedFrom;
+          expect(inheritsFrom).toBeString();
+          expect(inheritsFrom).not.toBeEmptyString();
+        });
+
+        it('should be a subclass of an existing model if subClassOf is provided', () => {
+          if (Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf')) {
+            const subClassModelShortName = jsonData.subClassOf.replace(/^#/, '');
+            const subClassModelFilename = `${subClassModelShortName}.json`;
+            const subClassModelExpectedFilepath = path.join(modelsDirpath, subClassModelFilename);
+            expect(fs.existsSync(subClassModelExpectedFilepath)).toBe(true);
+          }
+        });
+
+        it('should check that any schema.org class that a model derives from actually exists', () => {
+          if (
+            typeof jsonData.derivedFrom === 'string'
+          ) {
+            const derivedFromTypeId = jsonData.derivedFrom.replace(/^https/, 'http');
+            expect(schemaOrgDataModel.includes(derivedFromTypeId)).toBe(true);
+          }
+        });
+
         it('should check sameAs on fields actually exist when they are properties from schema.org', () => {
           for (const field in jsonData.fields) {
             if (
@@ -190,16 +214,6 @@ describe('models', () => {
                 expect(actual).toBe(true);
               }
             }
-          }
-        });
-
-        it('should check that any schema.org class that a model derives from actually exists', () => {
-          if (
-            typeof jsonData.derivedFrom === 'string'
-              && jsonData.derivedFrom.match(/^https:\/\/schema.org/)
-          ) {
-            const derivedFromClassId = jsonData.derivedFrom.replace(/^https/, 'http');
-            expect(schemaOrgDataModel.includes(derivedFromClassId)).toBe(true);
           }
         });
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -185,8 +185,7 @@ describe('models', () => {
           if (
             typeof jsonData.derivedFrom === 'string'
           ) {
-            const derivedFromTypeId = jsonData.derivedFrom.replace(/^https/, 'http');
-            expect(schemaOrgDataModel.includes(derivedFromTypeId)).toBe(true);
+            expect(jsonData.derivedFrom).toBeValidTypeReference();
           }
         });
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -276,7 +276,7 @@ describe('models', () => {
           }
         });
 
-        it('should have a fields property or a subClassOf property', () => {
+        it('should have a fields property', () => {
           expect(typeof jsonData.fields).toBe('object');
         });
 

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -165,9 +165,11 @@ describe('models', () => {
         });
 
         it('should be fit into the model inheritence hierarchy', () => {
-          const inheritsFrom = Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf') ? jsonData.subClassOf : jsonData.derivedFrom;
-          expect(inheritsFrom).toBeString();
-          expect(inheritsFrom).not.toBeEmptyString();
+          if (!file.match(/^Feed/)) { // Models for feed aren't part of the main model hierarchy
+            const inheritsFrom = Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf') ? jsonData.subClassOf : jsonData.derivedFrom;
+            expect(inheritsFrom).toBeString();
+            expect(inheritsFrom).not.toBeEmptyString();
+          }
         });
 
         it('should be a subclass of an existing model or class in vocab if subClassOf is provided', () => {

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -170,12 +170,14 @@ describe('models', () => {
           expect(inheritsFrom).not.toBeEmptyString();
         });
 
-        it('should be a subclass of an existing model if subClassOf is provided', () => {
+        it('should be a subclass of an existing model or class in vocab if subClassOf is provided', () => {
           if (Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf')) {
-            const subClassModelShortName = jsonData.subClassOf.replace(/^#/, '');
-            const subClassModelFilename = `${subClassModelShortName}.json`;
-            const subClassModelExpectedFilepath = path.join(modelsDirpath, subClassModelFilename);
-            expect(fs.existsSync(subClassModelExpectedFilepath)).toBe(true);
+            expect(jsonData.subClassOf).not.toStartWith('ArrayOf#');
+            if (jsonData.subClassOf.startsWith('http')) {
+              expect(jsonData.subClassOf).toBeValidTypeReference();
+            } else {
+              expect(jsonData.subClassOf).toBeValidModelReference();
+            }
           }
         });
 

--- a/versions/2.x/models/Lease.json
+++ b/versions/2.x/models/Lease.json
@@ -1,6 +1,6 @@
 {
    "type":"Lease",
-   "derivedFrom": "#Thing",
+   "subClassOf": "#Thing",
    "status":{
       "response":{
          "hasId":false,

--- a/versions/2.x/models/Parking.json
+++ b/versions/2.x/models/Parking.json
@@ -1,7 +1,7 @@
 {
   "type": "Parking",
-  "derivedFrom": "#Thing",
   "subClassOf": "#LocationFeatureSpecification",
+  "derivedFrom": null,
   "fields": {
     "type": {
       "fieldName": "type",

--- a/versions/2.x/models/Schedule.json
+++ b/versions/2.x/models/Schedule.json
@@ -1,6 +1,6 @@
 {
   "type": "Schedule",
-  "derivedFrom": "https://pending.schema.org/Schedule",
+  "derivedFrom": "https://schema.org/Schedule",
   "hasId": false,
   "requiredFields": [
     "type",


### PR DESCRIPTION
Fixes #24 

Approach is to make sure every model has a subClassOf or derivedFrom property in test then to validate the models and types referenced by subClassOf and derivedFrom in other tests.