### PR TITLE
add test to check models don't subclass a schema.org type instead of a local model

### DIFF
--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -183,6 +183,17 @@ describe('models', () => {
           }
         });
 
+        describe('subClassOf', () => {
+          it('should refer to local model if it exists', () => {
+            if (Object.prototype.hasOwnProperty.call(jsonData, 'subClassOf')) {
+              if (jsonData.subClassOf.startsWith('https://schema.org/')) {
+                const modelName = jsonData.subClassOf.replace(/^https:\/\/schema.org\//, '#');
+                expect(modelName).not.toBeValidModelReference();
+              }
+            }
+          });
+        });
+
         it('should contain derivedFrom property that refers to a class that actually exists', () => {
           if (
             typeof jsonData.derivedFrom === 'string'


### PR DESCRIPTION
Fixes #40 

Strictly speaking this is less strict than issue as there's no simple way to derive a potential model name from a type id so this test just checks that is subclassing from schema.org then make sure the data type name doesn't match to a local model name.