### PR TITLE
Add tests for imperativeConfiguration and validationMode

### DIFF
--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -495,7 +495,7 @@ describe('models', () => {
         });
 
         describe('validationMode', () => {
-          it('should pointt to entries in imperativeConfiguration', () => {
+          it('should point to entries in imperativeConfiguration', () => {
             if (Object.prototype.hasOwnProperty.call(jsonData, 'validationMode')) {
               for (const imperativeConfigurationKey of Object.values(jsonData.validationMode)) {
                 expect(Object.keys(jsonData.imperativeConfiguration)).toContain(imperativeConfigurationKey);

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -477,6 +477,32 @@ describe('models', () => {
             }
           });
         });
+
+        describe('imperativeConfiguration', () => {
+          ['requiredFields', 'recommendedFields', 'shallNotInclude'].forEach((fieldRestriction) => {
+            describe(fieldRestriction, () => {
+              it('should only contain fields from inSpec', () => {
+                if (Object.prototype.hasOwnProperty.call(jsonData, 'imperativeConfiguration')) {
+                  for (const config of Object.values(jsonData.imperativeConfiguration)) {
+                    for (const fieldName of config[fieldRestriction]) {
+                      expect(jsonData.inSpec).toContain(fieldName);
+                    }
+                  }
+                }
+              });
+            });
+          });
+        });
+
+        describe('validationMode', () => {
+          it('should pointt to entries in imperativeConfiguration', () => {
+            if (Object.prototype.hasOwnProperty.call(jsonData, 'validationMode')) {
+              for (const imperativeConfigurationKey of Object.values(jsonData.validationMode)) {
+                expect(Object.keys(jsonData.imperativeConfiguration)).toContain(imperativeConfigurationKey);
+              }
+            }
+          });
+        });
       });
 
       describe('namespaces', () => {


### PR DESCRIPTION
Note that there are no models yet that use these keys but instead this is part of https://github.com/openactive/data-models/issues/41

This does not include check that any validationMode referred to in a specification is valid because haven't done the work to move the list of valid validation modes into the repo from the data-model-validator repo.