### PR TITLE
Add validation modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openactive/data-models",
-  "version": "1.5.6",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openactive/data-models",
-  "version": "1.5.6",
+  "version": "2.0.0",
   "description": "Data models used to drive that OpenActive validator and developer documentation",
   "homepage": "http://openactive.io",
   "author": "Pete Walker <pete@imin.co> (https://github.com/petewalker)",

--- a/src/models-spec.js
+++ b/src/models-spec.js
@@ -631,6 +631,18 @@ describe('models', () => {
               }
             }
           });
+
+          it('should have keys which are validationModes from the metadata', () => {
+            if (Object.prototype.hasOwnProperty.call(jsonData, 'validationMode')) {
+              const allowedValidationModes = metaData.validationModeGroups.reduce((allModes, group) => {
+                const modesInGroup = group.validationModeList.map(modeObj => modeObj.validationMode);
+                return allModes.concat(modesInGroup);
+              }, []);
+              for (const validationMode of Object.keys(jsonData.validationMode)) {
+                expect(allowedValidationModes).toContain(validationMode);
+              }
+            }
+          });
         });
       });
 

--- a/versions/2.x/examples/booking_spec_examples/b_request_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/b_request_example_1.json
@@ -1,0 +1,57 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "Order",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123"
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132"
+      }
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  }
+}

--- a/versions/2.x/examples/booking_spec_examples/b_response_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/b_response_example_1.json
@@ -1,0 +1,170 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "Order",
+  "@id": "https://example.com/api/orders/e11429ea-467f-4270-ab62-e47368996fe8",
+  "orderNumber": "AB000001",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "@id": "https://example.com/api/orders/123e4567-e89b-12d3-a456-426655440000/order-items/1234",
+      "orderItemStatus": "https://openactive.io/OrderConfirmed",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      },
+      "accessToken": [
+        {
+          "@type": "Barcode",
+          "text": "0123456789"
+        }
+      ]
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 1,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ],
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  }
+}

--- a/versions/2.x/examples/booking_spec_examples/b_response_example_2_proposal.json
+++ b/versions/2.x/examples/booking_spec_examples/b_response_example_2_proposal.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "Order",
+  "orderProposalVersion": "https://example.com/api/order-proposals/e11429ea-467f-4270-ab62-e47368996fe8/version/8eb1a6ce-3f5b-40b0-87a7-bddb4c5518bd",
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  }
+}

--- a/versions/2.x/examples/booking_spec_examples/c1_request_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/c1_request_example_1.json
@@ -1,0 +1,40 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132"
+      }
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/c1_response_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/c1_response_example_1.json
@@ -1,0 +1,155 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "lease": {
+    "@type": "Lease",
+    "leaseExpires": "2018-10-01T11:00:00Z"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "maximumAttendeeCapacity": 30,
+        "remainingAttendeeCapacity": 20,
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "duration": "PT1H",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      }
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 1,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/c1_response_example_2_error.json
+++ b/versions/2.x/examples/booking_spec_examples/c1_response_example_2_error.json
@@ -1,0 +1,162 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "lease": {
+    "@type": "Lease",
+    "leaseExpires": "2018-10-01T11:00:00Z"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "orderItemStatus": "https://openactive.io/OrderConfirmed",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "maximumAttendeeCapacity": 30,
+        "remainingAttendeeCapacity": 20,
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "duration": "PT1H",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      },
+      "error": [
+        {
+          "@type": "OpportunityIsFullError",
+          "description": "There are no spaces remaining in this opportunity"
+        }
+      ]
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 0,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 0,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/c2_request_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/c2_request_example_1.json
@@ -1,0 +1,47 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123"
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132"
+      }
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/c2_response_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/c2_response_example_1.json
@@ -1,0 +1,162 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "lease": {
+    "@type": "Lease",
+    "leaseExpires": "2018-10-01T11:00:00Z"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "maximumAttendeeCapacity": 30,
+        "remainingAttendeeCapacity": 20,
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "duration": "PT1H",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      }
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 1,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/c2_response_example_2_error.json
+++ b/versions/2.x/examples/booking_spec_examples/c2_response_example_2_error.json
@@ -1,0 +1,169 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderQuote",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "lease": {
+    "@type": "Lease",
+    "leaseExpires": "2018-10-01T11:00:00Z"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "orderItemStatus": "https://openactive.io/OrderConfirmed",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "maximumAttendeeCapacity": 30,
+        "remainingAttendeeCapacity": 20,
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "duration": "PT1H",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      },
+      "error": [
+        {
+          "@type": "OpportunityIsFullError",
+          "description": "There are no spaces remaining in this opportunity"
+        }
+      ]
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 0,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 0,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/order_feed_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/order_feed_example_1.json
@@ -1,0 +1,98 @@
+{
+  "next": "/api/orders-rpde?afterTimestamp=1521565719&afterId=e11429ea-467f-4270-ab62-e47368996fe8",
+  "items": [
+    {
+      "state": "updated",
+      "kind": "Order",
+      "@id": "e11429ea-467f-4270-ab62-e47368996fe8",
+      "modified": 1521565719,
+      "data": {
+        "@context": "https://openactive.io/",
+        "@type": "Order",
+        "@id": "https://example.com/api/orders/e11429ea-467f-4270-ab62-e47368996fe8",
+        "seller": {
+          "@type": "Organization",
+          "@id": "https://example.com/api/organisations/123",
+          "identifier": "CRUOZWJ1",
+          "name": "Better",
+          "taxMode": "https://openactive.io/TaxGross",
+          "legalName": "Greenwich Leisure Limited",
+          "description": "A charitable social enterprise for all the community",
+          "url": "https://www.better.org.uk",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "http://data.better.org.uk/images/logo.png"
+          },
+          "telephone": "020 3457 8700",
+          "email": "customerservices@gll.org",
+          "vatID": "GB 789 1234 56",
+          "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "Alan Peacock Way",
+            "addressLocality": "Village East",
+            "addressRegion": "Middlesbrough",
+            "postalCode": "TS4 3AE",
+            "addressCountry": "GB"
+          },
+          "termsOfService": [
+            {
+              "@type": "Terms",
+              "name": "Privacy Policy",
+              "url": "https://example.com/privacy-policy"
+            },
+            {
+              "@type": "Terms",
+              "name": "Terms and Conditions",
+              "url": "https://example.com/terms-and-conditions"
+            }
+          ]
+        },
+        "orderedItem": [
+          {
+            "@type": "OrderItem",
+            "@id": "https://example.com/api/orders/123e4567-e89b-12d3-a456-426655440000/order-items/1234",
+            "orderItemStatus": "https://openactive.io/OrderConfirmed",
+            "allowCustomerCancellationFullRefund": true,
+            "unitTaxSpecification": [
+              {
+                "@type": "TaxChargeSpecification",
+                "name": "VAT at 0% for EU transactions",
+                "price": 1,
+                "priceCurrency": "GBP",
+                "rate": 0.2
+              }
+            ],
+            "acceptedOffer": {
+              "@type": "Offer",
+              "@id": "https://example.com/events/452#/offers/878",
+              "description": "Winger space for Speedball.",
+              "name": "Speedball winger position",
+              "price": 10,
+              "priceCurrency": "GBP",
+              "validFromBeforeStartDate": "P6D",
+              "latestCancellationBeforeStartDate": "P1D"
+            },
+            "orderedItem": {
+              "@type": "ScheduledSession",
+              "@id": "https://example.com/events/452/subEvents/132"
+            }
+          }
+        ],
+        "totalPaymentDue": {
+          "@type": "PriceSpecification",
+          "price": 5,
+          "priceCurrency": "GBP"
+        },
+        "totalPaymentTax": [
+          {
+            "@type": "TaxChargeSpecification",
+            "name": "VAT at 20%",
+            "price": 1,
+            "priceCurrency": "GBP",
+            "rate": 0.2
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/order_patch_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/order_patch_example_1.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "Order",
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "@id": "https://example.com/api/orders/123e4567-e89b-12d3-a456-426655440000/order-items/1234",
+      "orderItemStatus": "https://openactive.io/CustomerCancelled"
+    }
+  ]
+}

--- a/versions/2.x/examples/booking_spec_examples/orderproposal_patch_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/orderproposal_patch_example_1.json
@@ -1,0 +1,6 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderProposal",
+  "orderProposalStatus": "https://openactive.io/CustomerRejected",
+  "orderCustomerNote": "Sorry I've actually made other plans, hope you find someone!"
+}

--- a/versions/2.x/examples/booking_spec_examples/orderstatus_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/orderstatus_example_1.json
@@ -1,0 +1,169 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "Order",
+  "@id": "https://example.com/api/orders/e11429ea-467f-4270-ab62-e47368996fe8",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "@id": "https://example.com/api/orders/123e4567-e89b-12d3-a456-426655440000/order-items/1234",
+      "orderItemStatus": "https://openactive.io/OrderConfirmed",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      },
+      "accessToken": [
+        {
+          "@type": "Barcode",
+          "text": "0123456789"
+        }
+      ]
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 1,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ],
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  }
+}

--- a/versions/2.x/examples/booking_spec_examples/p_request_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/p_request_example_1.json
@@ -1,0 +1,57 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderProposal",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123"
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132"
+      }
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  }
+}

--- a/versions/2.x/examples/booking_spec_examples/p_response_example_1.json
+++ b/versions/2.x/examples/booking_spec_examples/p_response_example_1.json
@@ -1,0 +1,175 @@
+{
+  "@context": "https://openactive.io/",
+  "@type": "OrderProposal",
+  "@id": "https://example.com/api/order-proposals/e11429ea-467f-4270-ab62-e47368996fe8",
+  "orderNumber": "AB000001",
+  "orderProposalVersion": "https://example.com/api/order-proposals/e11429ea-467f-4270-ab62-e47368996fe8/version/8eb1a6ce-3f5b-40b0-87a7-bddb4c5518bd",
+  "brokerRole": "https://openactive.io/AgentBroker",
+  "broker": {
+    "@type": "Organization",
+    "name": "MyFitnessApp",
+    "url": "https://myfitnessapp.example.com",
+    "description": "A fitness app for all the community",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.myfitnessapp.org.uk/images/logo.png"
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    }
+  },
+  "seller": {
+    "@type": "Organization",
+    "@id": "https://example.com/api/organisations/123",
+    "identifier": "CRUOZWJ1",
+    "name": "Better",
+    "taxMode": "https://openactive.io/TaxGross",
+    "legalName": "Greenwich Leisure Limited",
+    "description": "A charitable social enterprise for all the community",
+    "url": "https://www.better.org.uk",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "http://data.better.org.uk/images/logo.png"
+    },
+    "telephone": "020 3457 8700",
+    "email": "customerservices@gll.org",
+    "vatID": "GB 789 1234 56",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Alan Peacock Way",
+      "addressLocality": "Village East",
+      "addressRegion": "Middlesbrough",
+      "postalCode": "TS4 3AE",
+      "addressCountry": "GB"
+    },
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "name": "Privacy Policy",
+        "url": "https://example.com/privacy-policy"
+      },
+      {
+        "@type": "Terms",
+        "name": "Terms and Conditions",
+        "url": "https://example.com/terms-and-conditions"
+      }
+    ]
+  },
+  "customer": {
+    "@type": "Person",
+    "email": "geoffcapes@example.com",
+    "telephone": "020 811 8055",
+    "givenName": "Geoff",
+    "familyName": "Capes"
+  },
+  "bookingService": {
+    "@type": "BookingService",
+    "name": "Playwaze",
+    "url": "http://www.playwaze.com",
+    "termsOfService": [
+      {
+        "@type": "Terms",
+        "url": "https://brokerexample.com/terms.html"
+      }
+    ]
+  },
+  "orderedItem": [
+    {
+      "@type": "OrderItem",
+      "@id": "https://example.com/api/orders/123e4567-e89b-12d3-a456-426655440000/order-items/1234",
+      "orderItemStatus": "https://openactive.io/OrderConfirmed",
+      "allowCustomerCancellationFullRefund": true,
+      "unitTaxSpecification": [
+        {
+          "@type": "TaxChargeSpecification",
+          "name": "VAT at 0% for EU transactions",
+          "price": 1,
+          "priceCurrency": "GBP",
+          "rate": 0.2
+        }
+      ],
+      "acceptedOffer": {
+        "@type": "Offer",
+        "@id": "https://example.com/events/452#/offers/878",
+        "description": "Winger space for Speedball.",
+        "name": "Speedball winger position",
+        "price": 10,
+        "priceCurrency": "GBP",
+        "validFromBeforeStartDate": "P6D",
+        "latestCancellationBeforeStartDate": "P1D"
+      },
+      "orderedItem": {
+        "@type": "ScheduledSession",
+        "@id": "https://example.com/events/452/subEvents/132",
+        "identifier": 123,
+        "eventStatus": "https://schema.org/EventScheduled",
+        "startDate": "2018-10-30T11:00:00Z",
+        "endDate": "2018-10-30T12:00:00Z",
+        "duration": "PT1H",
+        "superEvent": {
+          "@type": "SessionSeries",
+          "@id": "https://example.com/events/452",
+          "name": "Speedball",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Central Speedball Association",
+            "url": "http://www.speedball-world.com"
+          },
+          "location": {
+            "@type": "Place",
+            "url": "https://www.everyoneactive.com/centres/Middlesbrough-Sports-Village",
+            "name": "Middlesbrough Sports Village",
+            "identifier": "0140",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Alan Peacock Way",
+              "addressLocality": "Village East",
+              "addressRegion": "Middlesbrough",
+              "postalCode": "TS4 3AE",
+              "addressCountry": "GB"
+            },
+            "geo": {
+              "@type": "GeoCoordinates",
+              "latitude": 54.543964,
+              "longitude": -1.20978500000001
+            }
+          }
+        }
+      },
+      "accessToken": [
+        {
+          "@type": "Barcode",
+          "text": "0123456789"
+        }
+      ]
+    }
+  ],
+  "totalPaymentDue": {
+    "@type": "PriceSpecification",
+    "price": 5,
+    "priceCurrency": "GBP"
+  },
+  "totalPaymentTax": [
+    {
+      "@type": "TaxChargeSpecification",
+      "name": "VAT at 20%",
+      "price": 1,
+      "priceCurrency": "GBP",
+      "rate": 0.2
+    }
+  ],
+  "payment": {
+    "@type": "Payment",
+    "name": "AcmeBroker Points",
+    "identifier": "1234567890npduy2f"
+  },
+  "lease": {
+    "@type": "Lease",
+    "leaseExpires": "2018-10-01T11:00:00Z"
+  }
+}

--- a/versions/2.x/examples/example_list.json
+++ b/versions/2.x/examples/example_list.json
@@ -43,5 +43,75 @@
         "name": "Event Example"
       }
     ]
+  },
+  {
+    "name": "Open Booking API - Simple",
+    "exampleList": [
+      {
+        "file": "booking_spec_examples/c1_request_example_1.json",
+        "name": "C1 Request Example",
+        "validationMode": "C1Request"
+      },
+      {
+        "file": "booking_spec_examples/c1_response_example_1.json",
+        "name": "C1 Response Example",
+        "validationMode": "C1Response"
+      },
+      {
+        "file": "booking_spec_examples/c2_request_example_1.json",
+        "name": "C2 Request Example",
+        "validationMode": "C2Request"
+      },
+      {
+        "file": "booking_spec_examples/c2_response_example_1.json",
+        "name": "C2 Response Example",
+        "validationMode": "C2Response"
+      },
+      {
+        "file": "booking_spec_examples/b_request_example_1.json",
+        "name": "B Request Example",
+        "validationMode": "BRequest"
+      },
+      {
+        "file": "booking_spec_examples/b_response_example_1.json",
+        "name": "B Response Example",
+        "validationMode": "BResponse"
+      },
+      {
+        "file": "booking_spec_examples/order_patch_example_1.json",
+        "name": "Order Patch Example (Cancellation)",
+        "validationMode": "OrderPatch"
+      },
+      {
+        "file": "booking_spec_examples/order_feed_example_1.json",
+        "name": "Order Feed Example",
+        "validationMode": "OrderFeed"
+      },
+      {
+        "file": "booking_spec_examples/orderstatus_example_1.json",
+        "name": "OrderStatus Example",
+        "validationMode": "OrderStatus"
+      }
+    ]
+  },
+  {
+    "name": "Open Booking API - Approval",
+    "exampleList": [
+      {
+        "file": "booking_spec_examples/p_request_example_1.json",
+        "name": "P Request Example",
+        "validationMode": "PRequest"
+      },
+      {
+        "file": "booking_spec_examples/p_response_example_1.json",
+        "name": "P Response Example",
+        "validationMode": "PResponse"
+      },
+      {
+        "file": "booking_spec_examples/orderproposal_patch_example_1.json",
+        "name": "OrderProposal Example",
+        "validationMode": "OrderProposalPatch"
+      }
+    ]
   }
 ]

--- a/versions/2.x/examples/example_list.json
+++ b/versions/2.x/examples/example_list.json
@@ -1,42 +1,47 @@
 [
   {
-    "file": "sessionseries_example_1.json",
-    "name": "SessionSeries with ScheduledSession Example"
-  },
-  {
-    "file": "scheduledsession_example_1.json",
-    "name": "ScheduledSession with SessionSeries Example"
-  },
-  {
-    "file": "sessionseries-split_example_1.json",
-    "name": "SessionSeries Example"
-  },
-  {
-    "file": "scheduledsession-split_example_1.json",
-    "name": "ScheduledSession Example"
-  },
-  {
-    "file": "sessionseries-eventseries-split_example_1.json",
-    "name": "SessionSeries with EventSeries Example"
-  },
-  {
-    "file": "facilityuse_example_1.json",
-    "name": "FacilityUse Example"
-  },
-  {
-    "file": "slot_example_1.json",
-    "name": "Slot Example"
-  },
-  {
-    "file": "courseinstance_example_1.json",
-    "name": "CourseInstance Example"
-  },
-  {
-    "file": "courseinstance_event_example_1.json",
-    "name": "CourseInstance with Event Example"
-  },
-  {
-    "file": "event_example_1.json",
-    "name": "Event Example"
+    "name": "Opportunity Data Publishing",
+    "exampleList": [
+      {
+        "file": "sessionseries_example_1.json",
+        "name": "SessionSeries with ScheduledSession Example"
+      },
+      {
+        "file": "scheduledsession_example_1.json",
+        "name": "ScheduledSession with SessionSeries Example"
+      },
+      {
+        "file": "sessionseries-split_example_1.json",
+        "name": "SessionSeries Example"
+      },
+      {
+        "file": "scheduledsession-split_example_1.json",
+        "name": "ScheduledSession Example"
+      },
+      {
+        "file": "sessionseries-eventseries-split_example_1.json",
+        "name": "SessionSeries with EventSeries Example"
+      },
+      {
+        "file": "facilityuse_example_1.json",
+        "name": "FacilityUse Example"
+      },
+      {
+        "file": "slot_example_1.json",
+        "name": "Slot Example"
+      },
+      {
+        "file": "courseinstance_example_1.json",
+        "name": "CourseInstance Example"
+      },
+      {
+        "file": "courseinstance_event_example_1.json",
+        "name": "CourseInstance with Event Example"
+      },
+      {
+        "file": "event_example_1.json",
+        "name": "Event Example"
+      }
+    ]
   }
 ]

--- a/versions/2.x/meta.json
+++ b/versions/2.x/meta.json
@@ -208,6 +208,42 @@
         {
           "validationMode": "C2Request",
           "name": "C2 Request"
+        },
+        {
+          "validationMode": "C2Response",
+          "name": "C2 Response"
+        },
+        {
+          "validationMode": "PRequest",
+          "name": "P Request"
+        },
+        {
+          "validationMode": "PResponse",
+          "name": "P Response"
+        },
+        {
+          "validationMode": "BRequest",
+          "name": "B Request"
+        },
+        {
+          "validationMode": "BResponse",
+          "name": "B Response"
+        },
+        {
+          "validationMode": "OrderProposalPatch",
+          "name": "OrderProposal Patch"
+        },
+        {
+          "validationMode": "OrderPatch",
+          "name": "Order Patch"
+        },
+        {
+          "validationMode": "OrderFeed",
+          "name": "Order Feed"
+        },
+        {
+          "validationMode": "OrderStatus",
+          "name": "OrderStatus"
         }
       ]
     }

--- a/versions/2.x/meta.json
+++ b/versions/2.x/meta.json
@@ -183,5 +183,33 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "pending": "https://pending.schema.org/",
     "gr": "http://purl.org/goodrelations/v1#"
-  }
+  },
+  "validationModeGroups":[
+    {
+      "name": "Opportunity Data Publishing",
+      "validationModeList": [
+        {
+          "validationMode": "RPDEFeed",
+          "name": "RPDE Feed"
+        }
+      ]
+    },
+    {
+      "name": "Open Booking API",
+      "validationModeList": [
+        {
+          "validationMode": "C1Request",
+          "name": "C1 Request"
+        },
+        {
+          "validationMode": "C1Response",
+          "name": "C1 Response"
+        },
+        {
+          "validationMode": "C2Request",
+          "name": "C2 Request"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Part of #41 

Update 2.0 spec's metadata to include validation mode groups. And is a related change update the format of examples to group them according to usage (ready to add Booking examples which may also have a validation mode associated with them).