### PR TITLE
Add facilityType and update examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openactive/data-models",
-  "version": "2.0.255",
+  "version": "2.0.259",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openactive/data-models",
-  "version": "2.0.255",
+  "version": "2.0.259",
   "description": "Data models used to drive that OpenActive validator, developer documentation, and model libraries",
   "homepage": "https://www.openactive.io",
   "author": "OpenActive Community <hello@openactive.io>",

--- a/versions/2.x/examples/facilityuse_example_1.json
+++ b/versions/2.x/examples/facilityuse_example_1.json
@@ -13,14 +13,14 @@
         ],
         "@type": "FacilityUse",
         "@id": "http://www.example.org/facility-uses/1",
-        "name": "Example Leisure Centre Outdoor Tennis",
-        "description": "Table courts are available to hire for thirty minute slots",
-        "activity": [
+        "name": "Outdoor Tennis",
+        "description": "Tennis courts are available to hire for thirty minute slots",
+        "facilityType": [
           {
-            "@id": "https://openactive.io/activity-list#f2ea7405-6098-4378-b0fe-4e398a659fc4",
-            "inScheme": "https://openactive.io/activity-list",
-            "prefLabel": "Tennis",
-            "@type": "Concept"
+            "@type": "Concept",
+            "@id": "https://openactive.io/facility-types#bba8ae59-d152-40bc-85cc-88c5375696d4",
+            "prefLabel": "Tennis Court",
+            "inScheme": "https://openactive.io/facility-types"
           }
         ],
         "provider": {
@@ -155,27 +155,19 @@
             "url": "http://example.org/images/1.jpg"
           }
         ],
-        "beta:sportsActivityLocation": [
+        "individualFacilityUse": [
           {
-            "@type": "SportsActivityLocation",
-            "name": "Main Tennis Court 1",
-            "containedInPlace": "http://www.example.org/api/locations/8958f9b8-2004-4e90-80ff-50c98a9b121d"
+            "@type": "IndividualFacilityUse",
+            "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/1",
+            "name": "Main Tennis Court 1"
           },
           {
-            "@type": "SportsActivityLocation",
-            "name": "Main Tennis Court 2",
-            "containedInPlace": "http://www.example.org/api/locations/8958f9b8-2004-4e90-80ff-50c98a9b121d"
+            "@type": "IndividualFacilityUse",
+            "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/2",
+            "name": "Main Tennis Court 2"
           }
         ],
-        "beta:facilitySetting": "https://openactive.io/ns-beta#IndoorFacility",
-        "beta:facilityType": [
-          {
-            "@type": "Concept",
-            "@id": "https://openactive.io/facility-types#a5ac16fe-06ac-4bc1-93f7-69ff3bfcf3b9",
-            "prefLabel": "3G Artificial Grass",
-            "inScheme": "https://openactive.io/facility-types"
-          }
-        ],
+        "beta:facilitySetting": "https://openactive.io/ns-beta#OutdoorFacility",
         "offers": [
           {
             "@type": "Offer",

--- a/versions/2.x/examples/slot_example_1.json
+++ b/versions/2.x/examples/slot_example_1.json
@@ -1,21 +1,21 @@
 {
-  "next": "http://www.example.org/feeds/facility-uses/events?afterChangeNumber=44254329",
+  "next": "http://www.example.org/feeds/individual-facility-use-slots?afterChangeNumber=44254329",
   "items": [
     {
       "state": "updated",
-      "kind": "FacilityUse/Slot",
+      "kind": "IndividualFacilityUse/Slot",
       "id": "009/2018-03-01T10:00:00Z",
       "modified": 44234351,
       "data": {
         "@context": "https://openactive.io/",
         "@type": "Slot",
-        "@id": "http://www.example.org/api/facility-uses/432#/event/2018-03-01T10:00:00Z",
-        "facilityUse": "http://www.example.org/api/facility-uses/432",
+        "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/1#/slots/2018-03-01T10:00:00Z",
+        "facilityUse": "http://www.example.org/facility-uses/1/individual-facility-uses/1",
         "startDate": "2018-03-01T11:00:00Z",
         "endDate": "2018-03-01T11:30:00Z",
         "duration": "PT30M",
-        "remainingUses": 3,
-        "maximumUses": 6,
+        "remainingUses": 1,
+        "maximumUses": 1,
         "offers": [
           {
             "@type": "Offer",

--- a/versions/2.x/models/FacilityUse.json
+++ b/versions/2.x/models/FacilityUse.json
@@ -8,9 +8,19 @@
     "id",
     "url",
     "name",
-    "activity",
     "location",
     "provider"
+  ],
+  "requiredOptions": [
+    {
+      "description": [
+        "Support for the `facilityType` property has been added to tooling and documentation ahead of inclusion in the next point release of the OpenActive Modelling Opportunity Data specification, as agreed on [the W3C call 2021-06-02](https://github.com/openactive/facility-types/issues/1#issuecomment-853759213). On this basis of this discussion, following the next point release, only `facilityType` will be required."
+      ],
+      "options": [
+        "facilityType",
+        "activity"
+      ]
+    }
   ],
   "recommendedFields": [
     "description",
@@ -41,7 +51,7 @@
         "type",
         "url",
         "name",
-        "activity",
+        "facilityType",
         "location"
       ],
       "shallNotInclude": [
@@ -59,6 +69,7 @@
     "name",
     "description",
     "image",
+    "facilityType",
     "activity",
     "location",
     "event",
@@ -105,6 +116,23 @@
         }
       ]
     },
+    "facilityType": {
+      "fieldName": "facilityType",
+      "sameAs": "https://openactive.io/facilityType",
+      "model": "ArrayOf#Concept",
+      "description": [
+        "Specifies the types of facility being described.",
+        "NOTE: this property has been added to tooling and documentation ahead of inclusion in the next point release of the OpenActive Modelling Opportunity Data specification, as agreed on [the W3C call 2021-06-02](https://github.com/openactive/facility-types/issues/1#issuecomment-853759213)."
+      ],
+      "example": [
+        {
+          "@type": "Concept",
+          "@id": "https://openactive.io/facility-types#bba8ae59-d152-40bc-85cc-88c5375696d4",
+          "prefLabel": "Tennis Court",
+          "inScheme": "https://openactive.io/facility-types"
+        }
+      ]
+    },
     "activity": {
       "fieldName": "activity",
       "sameAs": "https://openactive.io/activity",
@@ -119,7 +147,8 @@
           "prefLabel": "Badminton",
           "inScheme": "https://openactive.io/activity-list"
         }
-      ]
+      ],
+      "deprecationGuidance": "Use `facilityType` instead of `activity` within `FacilityUse` and `IndividualFacilityUse`, as the `facilityType` controlled vocabulary has been designed specifically for facilities."
     },
     "attendeeInstructions": {
       "fieldName": "attendeeInstructions",
@@ -222,10 +251,13 @@
       "example": [
         {
           "@type": "IndividualFacilityUse",
-          "@id": "http://www.example.org/facility-uses/1",
+          "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/1",
           "name": "Tennis Court 1"
         }
-      ]
+      ],
+      "inheritsTo": {
+        "exclude": ["id", "identifier", "individualFacilityUse", "name"]
+      }
     },
     "location": {
       "fieldName": "location",

--- a/versions/2.x/models/IndividualFacilityUse.json
+++ b/versions/2.x/models/IndividualFacilityUse.json
@@ -8,16 +8,24 @@
     "id",
     "url",
     "name",
-    "activity",
     "location",
     "provider"
+  ],
+  "requiredOptions": [
+    {
+      "description": [
+        "Support for the `facilityType` property has been added to tooling and documentation ahead of inclusion in the next point release of the OpenActive Modelling Opportunity Data specification, as agreed on [the W3C call 2021-06-02](https://github.com/openactive/facility-types/issues/1#issuecomment-853759213). On this basis of this discussion, following the next point release, only `facilityType` will be required."
+      ],
+      "options": [
+        "facilityType",
+        "activity"
+      ]
+    }
   ],
   "recommendedFields": [
     "description",
     "image",
-    "hoursAvailable",
-    "aggregateFacilityUse",
-    "event"
+    "hoursAvailable"
   ],
   "notInSpec": [
     "individualFacilityUse"
@@ -31,6 +39,7 @@
     "name",
     "description",
     "image",
+    "facilityType",
     "activity",
     "location",
     "event",
@@ -58,7 +67,10 @@
       "model": "#FacilityUse",
       "description": [
         "Inverse of the oa:individualFacilityUse property. Relates an oa:IndividualFacilityUse (e.g. an opportunity to play tennis on a specific court) to a oa:FacilityUse (e.g. an opportunity to play tennis at a specific location)."
-      ]
+      ],
+      "inheritsFrom": {
+        "exclude": ["id", "identifier", "aggregateFacilityUse", "name"]
+      }
     },
     "event": {
       "fieldName": "event",


### PR DESCRIPTION
Add `facilityType` property as per discussion https://github.com/openactive/facility-types/issues/1 ahead of inclusion in the next point release of the OpenActive Modelling Opportunity Data specification, as agreed on [the W3C call 2021-06-02](https://github.com/openactive/facility-types/issues/1#issuecomment-853759213).

Also update examples to include use of `facilityType`, as well as to prefer the use of `IndividualFacilityUse` as per https://github.com/openactive/developer-documentation/issues/48.

This PR allows either `facilityType` or `activity` to be specified, for backwards compatibility.
