### PR TITLE
Add beta:sportsActivityLocation to examples

### DIFF
--- a/versions/2.x/examples/facilityuse_example_1.json
+++ b/versions/2.x/examples/facilityuse_example_1.json
@@ -159,12 +159,26 @@
           {
             "@type": "IndividualFacilityUse",
             "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/1",
-            "name": "Main Tennis Court 1"
+            "name": "Outdoor Tennis on Main Tennis Court 1",
+            "beta:sportsActivityLocation": [
+              {
+                "type": "SportsActivityLocation",
+                "name": "Main Tennis Court 1",
+                "containedInPlace": "http://www.example.org/api/locations/8958f9b8-2004-4e90-80ff-50c98a9b121d"
+              }
+            ]
           },
           {
             "@type": "IndividualFacilityUse",
             "@id": "http://www.example.org/facility-uses/1/individual-facility-uses/2",
-            "name": "Main Tennis Court 2"
+            "name": "Outdoor Tennis on Main Tennis Court 2",
+            "beta:sportsActivityLocation": [
+              {
+                "type": "SportsActivityLocation",
+                "name": "Main Tennis Court 2",
+                "containedInPlace": "http://www.example.org/api/locations/8958f9b8-2004-4e90-80ff-50c98a9b121d"
+              }
+            ]
           }
         ],
         "beta:facilitySetting": "https://openactive.io/ns-beta#OutdoorFacility",

--- a/versions/2.x/examples/scheduledsession-split_example_1.json
+++ b/versions/2.x/examples/scheduledsession-split_example_1.json
@@ -18,7 +18,14 @@
         "eventStatus": "https://schema.org/EventScheduled",
         "maximumAttendeeCapacity": 10,
         "remainingAttendeeCapacity": 0,
-        "url": "https://bookwhen.com/hulafit/e/ev-ssyp-20160510011500?r=oa"
+        "url": "https://bookwhen.com/hulafit/e/ev-ssyp-20160510011500?r=oa",
+        "beta:sportsActivityLocation": [
+          {
+            "type": "SportsActivityLocation",
+            "name": "Yoga Studio",
+            "containedInPlace": "http://www.example.org/api/locations/8958f9b8-2004-4e90-80ff-50c98a9b121d"
+          }
+        ]
       }
     }
   ],

--- a/versions/2.x/models/FacilityUse.json
+++ b/versions/2.x/models/FacilityUse.json
@@ -297,7 +297,7 @@
     },
     "provider": {
       "fieldName": "provider",
-      "sameAs": "https://schema.org/provider",
+      "sameAs": "https://pending.schema.org/provider",
       "model": "#Organization",
       "description": [
         "The organisation responsible for providing the facility"

--- a/versions/2.x/models/Place.json
+++ b/versions/2.x/models/Place.json
@@ -151,7 +151,8 @@
       },
       "description": [
         "The place within which this Place exists"
-      ]
+      ],
+      "allowReferencing": true
     },
     "containsPlace": {
       "fieldName": "containsPlace",


### PR DESCRIPTION
- Add `beta:sportsActivityLocation` from https://github.com/openactive/modelling-opportunity-data/issues/110 to examples to aid implementations.
- Allow `containedInPlace` to include `@id` references as per the beta proposal