### PR TITLE
feat: Make getExamplesWithContent more comprehensive

### DIFF
--- a/src/getExamplesWithContent-spec.js
+++ b/src/getExamplesWithContent-spec.js
@@ -6,14 +6,29 @@ describe('getExamplesWithContent', () => {
   });
 
   it('should return valid examples as JSON', async () => {
-    const examples = await getExamplesWithContent('2.0');
+    const examples = getExamplesWithContent('2.0');
     expect(typeof examples).toBe('object');
     expect(examples instanceof Array).toBe(true);
   });
 
   it('should return valid examples as JSON with a version alias', async () => {
-    const examples = await getExamplesWithContent('latest');
+    const examples = getExamplesWithContent('latest');
     expect(typeof examples).toBe('object');
     expect(examples instanceof Array).toBe(true);
+  });
+
+  it('should use remote fetcher for remote examples', async () => {
+    const mockFetcher = x => `Fetcher:${x}`;
+
+    const examples = getExamplesWithContent('latest', mockFetcher);
+    expect(typeof examples).toBe('object');
+    expect(examples instanceof Array).toBe(true);
+
+    const remoteExamples = examples.filter(x => x.file.indexOf('http') === 0);
+    expect(remoteExamples).toBeNonEmptyArray();
+
+    for (const { file, data } of remoteExamples) {
+      expect(data).toBe(mockFetcher(file));
+    }
   });
 });

--- a/src/getExamplesWithContent-spec.js
+++ b/src/getExamplesWithContent-spec.js
@@ -2,7 +2,7 @@ const getExamplesWithContent = require('./getExamplesWithContent');
 
 describe('getExamplesWithContent', () => {
   it('should throw if passed an invalid spec version', async () => {
-    expectAsync(getExamplesWithContent('0.0')).toBeRejected();
+    expect(getExamplesWithContent('0.0')).toThrow();
   });
 
   it('should return valid examples as JSON', async () => {

--- a/src/getExamplesWithContent-spec.js
+++ b/src/getExamplesWithContent-spec.js
@@ -2,7 +2,7 @@ const getExamplesWithContent = require('./getExamplesWithContent');
 
 describe('getExamplesWithContent', () => {
   it('should throw if passed an invalid spec version', async () => {
-    expect(getExamplesWithContent('0.0')).toThrow();
+    expect(() => getExamplesWithContent('0.0')).toThrow();
   });
 
   it('should return valid examples as JSON', async () => {

--- a/src/getExamplesWithContent.js
+++ b/src/getExamplesWithContent.js
@@ -1,19 +1,30 @@
-const fs = require('fs').promises;
+const fs = require('fs');
 const getExamples = require('./getExamples');
 
 const EXAMPLES_DIRECTORY = `${__dirname}/../versions/2.x/examples/`;
+const EXAMPLES_BASE_URL = 'https://openactive.io/data-models/versions/2.x/examples/';
 
-const getExamplesWithContent = async (version) => {
+
+const getExamplesWithContent = (version, fetcherForRemoteExamplesSync) => {
   const examples = getExamples(version);
+  const flattenedExamples = examples.flatMap(x => x.exampleList.map(example => ({ category: x.name, ...example })));
   const output = [];
-  for (const { file, name } of examples.flatMap(x => x.exampleList)) {
-    // Only include local examples
-    if (file.indexOf('http') !== 0) {
-      const data = JSON.parse(await fs.readFile(`${EXAMPLES_DIRECTORY}${file}`, { encoding: 'utf8' }));
+  for (const example of flattenedExamples) {
+    if (example.file.indexOf('http') !== 0) {
+      // Local example file
+      const data = JSON.parse(fs.readFileSync(`${EXAMPLES_DIRECTORY}${example.file}`, { encoding: 'utf8' }));
       output.push({
-        name,
-        file,
         data,
+        url: `${EXAMPLES_BASE_URL}${example.file}`,
+        ...example,
+      });
+    } else if (fetcherForRemoteExamplesSync) {
+      // Remote example file
+      const data = fetcherForRemoteExamplesSync(`${example.file}`);
+      output.push({
+        data,
+        url: example.file,
+        ...example,
       });
     }
   }


### PR DESCRIPTION
getExamplesWithContent now includes all examples and is synchronous so that it can be used more easily by dev tooling (e.g. generating tests)