### PR TITLE
feat: Improve dataset site model validation specificity

### DIFF
--- a/versions/2.x/models/BookingService.json
+++ b/versions/2.x/models/BookingService.json
@@ -15,7 +15,8 @@
     "BResponse": "response",
     "BResponseOrderItemError": "response",
     "OrderProposalPatch": "request",
-    "OrderPatch": "request"
+    "OrderPatch": "request",
+    "DatasetSite": "datasetSite"
   },
   "imperativeConfiguration": {
     "request": {
@@ -27,6 +28,21 @@
         "type",
         "name"
       ],
+      "recommendedFields": []
+    },
+    "datasetSite": {
+      "requiredOptions": [
+        {
+          "description": [
+            "A `BookingService` must include a `name`, unless it is an bespoke build, in which case `hasCredential` may be included as the only property."
+          ],
+          "options": [
+            "name",
+            "hasCredential"
+          ]
+        }
+      ],
+      "requiredFields": [],
       "recommendedFields": []
     }
   },

--- a/versions/2.x/models/Dataset.json
+++ b/versions/2.x/models/Dataset.json
@@ -3,26 +3,33 @@
   "derivedFrom": "https://schema.org/Dataset",
   "hasId": true,
   "sampleId": "https://opendata.fusion-lifestyle.com/OpenActive/",
-  "requiredFields": [
-    "id",
-    "type",
-    "url",
-    "name",
-    "description",
-    "keywords",
-    "license",
-    "distribution",
-    "discussionUrl",
-    "documentation",
-    "inLanguage",
-    "publisher",
-    "schemaVersion"
-  ],
-  "recommendedFields": [
-    "datePublished",
-    "dateModified",
-    "backgroundImage"
-  ],
+  "validationMode": {
+    "DatasetSite": "datasetSite"
+  },
+  "imperativeConfiguration": {
+    "datasetSite": {
+      "requiredFields": [
+        "id",
+        "type",
+        "url",
+        "name",
+        "description",
+        "keywords",
+        "license",
+        "distribution",
+        "discussionUrl",
+        "documentation",
+        "inLanguage",
+        "publisher",
+        "schemaVersion"
+      ],
+      "recommendedFields": [
+        "datePublished",
+        "dateModified",
+        "backgroundImage"
+      ]
+    }
+  },
   "inSpec": [
     "id",
     "type",

--- a/versions/2.x/models/WebAPI.json
+++ b/versions/2.x/models/WebAPI.json
@@ -2,18 +2,25 @@
   "type": "WebAPI",
   "derivedFrom": "https://pending.schema.org/WebAPI",
   "hasId": false,
-  "requiredFields": [
-    "type",
-    "name",
-    "endpointUrl",
-    "conformsTo",
-    "endpointDescription",
-    "landingPage"
-  ],
-  "recommendedFields": [
-    "documentation",
-    "termsOfService"
-  ],
+  "validationMode": {
+    "DatasetSite": "datasetSite"
+  },
+  "imperativeConfiguration": {
+    "datasetSite": {
+      "requiredFields": [
+        "type",
+        "name",
+        "endpointUrl",
+        "conformsTo",
+        "endpointDescription",
+        "landingPage"
+      ],
+      "recommendedFields": [
+        "documentation",
+        "termsOfService"
+      ]
+    }
+  },
   "inSpec": [
     "type",
     "name",


### PR DESCRIPTION
Improve dataset site model validation to apply to dataset sites only, which allows the models to be used elsewhere without issue