### PR TITLE
feat: Ensure docs are correct, while allowing flexibility for other use

### DIFF
--- a/versions/2.x/models/Dataset.json
+++ b/versions/2.x/models/Dataset.json
@@ -4,32 +4,53 @@
   "hasId": true,
   "sampleId": "https://opendata.fusion-lifestyle.com/OpenActive/",
   "validationMode": {
-    "DatasetSite": "datasetSite"
+    "RPDEFeed": "noRequired",
+    "BookableRPDEFeed": "noRequired",
+    "DataCatalog": "noRequired",
+    "C1Request": "noRequired",
+    "C1Response": "noRequired",
+    "C1ResponseOrderItemError": "noRequired",
+    "C2Request": "noRequired",
+    "C2Response": "noRequired",
+    "C2ResponseOrderItemError": "noRequired",
+    "PRequest": "noRequired",
+    "PResponse": "noRequired",
+    "PResponseOrderItemError": "noRequired",
+    "BRequest": "noRequired",
+    "BResponse": "noRequired",
+    "BResponseOrderItemError": "noRequired",
+    "OrderProposalPatch": "noRequired",
+    "OrderPatch": "noRequired",
+    "OrdersFeed": "noRequired",
+    "OrderProposalsFeed": "noRequired",
+    "OrderStatus": "noRequired"
   },
   "imperativeConfiguration": {
-    "datasetSite": {
-      "requiredFields": [
-        "id",
-        "type",
-        "url",
-        "name",
-        "description",
-        "keywords",
-        "license",
-        "distribution",
-        "discussionUrl",
-        "documentation",
-        "inLanguage",
-        "publisher",
-        "schemaVersion"
-      ],
-      "recommendedFields": [
-        "datePublished",
-        "dateModified",
-        "backgroundImage"
-      ]
+    "noRequired": {
+      "requiredFields": [],
+      "recommendedFields": []
     }
   },
+  "requiredFields": [
+    "id",
+    "type",
+    "url",
+    "name",
+    "description",
+    "keywords",
+    "license",
+    "distribution",
+    "discussionUrl",
+    "documentation",
+    "inLanguage",
+    "publisher",
+    "schemaVersion"
+  ],
+  "recommendedFields": [
+    "datePublished",
+    "dateModified",
+    "backgroundImage"
+  ],
   "inSpec": [
     "id",
     "type",

--- a/versions/2.x/models/WebAPI.json
+++ b/versions/2.x/models/WebAPI.json
@@ -3,24 +3,45 @@
   "derivedFrom": "https://pending.schema.org/WebAPI",
   "hasId": false,
   "validationMode": {
-    "DatasetSite": "datasetSite"
+    "RPDEFeed": "noRequired",
+    "BookableRPDEFeed": "noRequired",
+    "DataCatalog": "noRequired",
+    "C1Request": "noRequired",
+    "C1Response": "noRequired",
+    "C1ResponseOrderItemError": "noRequired",
+    "C2Request": "noRequired",
+    "C2Response": "noRequired",
+    "C2ResponseOrderItemError": "noRequired",
+    "PRequest": "noRequired",
+    "PResponse": "noRequired",
+    "PResponseOrderItemError": "noRequired",
+    "BRequest": "noRequired",
+    "BResponse": "noRequired",
+    "BResponseOrderItemError": "noRequired",
+    "OrderProposalPatch": "noRequired",
+    "OrderPatch": "noRequired",
+    "OrdersFeed": "noRequired",
+    "OrderProposalsFeed": "noRequired",
+    "OrderStatus": "noRequired"
   },
   "imperativeConfiguration": {
-    "datasetSite": {
-      "requiredFields": [
-        "type",
-        "name",
-        "endpointUrl",
-        "conformsTo",
-        "endpointDescription",
-        "landingPage"
-      ],
-      "recommendedFields": [
-        "documentation",
-        "termsOfService"
-      ]
+    "noRequired": {
+      "requiredFields": [],
+      "recommendedFields": []
     }
   },
+  "requiredFields": [
+    "type",
+    "name",
+    "endpointUrl",
+    "conformsTo",
+    "endpointDescription",
+    "landingPage"
+  ],
+  "recommendedFields": [
+    "documentation",
+    "termsOfService"
+  ],
   "inSpec": [
     "type",
     "name",


### PR DESCRIPTION
The previous solution #110 worked, but removed the status from properties in the documentation (which does not take into account `imperativeConfiguration`). This PR adds the status back in, while maintaining the same flexibility.